### PR TITLE
implement Twingle's double opt-in

### DIFF
--- a/CRM/Twingle/Form/Profile.php
+++ b/CRM/Twingle/Form/Profile.php
@@ -337,6 +337,13 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
     );
 
     $this->add(
+       'checkbox', // field type
+       'double_opt_in', // field name
+       E::ts('Use Twingle\'s Double-Opt-In procedure'), // field label
+       FALSE // is not required
+     );
+
+    $this->add(
       'select', // field type
       'postinfo_groups', // field name
       E::ts('Sign up for postal mail groups'), // field label

--- a/CRM/Twingle/Profile.php
+++ b/CRM/Twingle/Profile.php
@@ -221,6 +221,7 @@ class CRM_Twingle_Profile {
         'membership_type_id',
         'membership_type_id_recur',
         'membership_postprocess_call',
+        'double_opt_in'
       ),
       // Add payment methods.
       array_keys(static::paymentInstruments()),
@@ -293,6 +294,7 @@ class CRM_Twingle_Profile {
       'custom_field_mapping' => NULL,
       'membership_type_id' => NULL,
       'membership_type_id_recur' => NULL,
+      'double_opt_in' => NULL,
     )
       // Add contribution status for all payment methods.
       + array_fill_keys(array_map(function($attribute) {

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ for all newly created Twingle projects.
 | CiviSEPA creditor                     | When enabled to integrate with CiviSEPA, specify the CiviSEPA creditor to use.                                                                                                           |
 | Gender options                        | Specify which CiviCRM gender option the incoming Twingle gender value should be mapped to. The list is based on your CiviCRM configuration.                                              |
 | Record *Payment method* as            | Specifiy the payment methods mapping for incoming donations for each Twingle payment method.                                                                                             |
+| Double-Opt-In                         | Group membership for newsletter mailing lists will be pending until receivement of confirming API call. Usage in combination with activated Double-Opt-In in Twingle manager.            |
 | Sign up for groups                    | Whenever the donor checked the newsletter/postal mailing/donation receipt checkbox on the Twingle form, the contact will be added to the groups listed here.                             |
 | Assign donation to campaign           | The donation will be assigned to the selected campaign. If a campaign ID is being submitted using the `campaign_id` parameter, this setting will be overridden with the submitted value. |
 | Create membership of type             | A membership of the selected type will be created for the Individual contact for incoming one-time donations. If no membership type is selected, no membership will be created.          |
@@ -147,4 +148,20 @@ The action accepts the following parameters:
 
 You may also refer to
 [the code](https://github.com/systopia/de.systopia.twingle/blob/master/api/v3/TwingleDonation/Cancel.php)
+for more insight into this API action.
+
+### Double-Opt-In confirmation
+
+- Entity: `TwingleDonation`
+- Action: `doubleoptinconfirm`
+
+The action accepts the following parameters:
+
+| Parameter                    | Type   | Description                                        | Values/Format                                         | Required |
+|------------------------------|--------|----------------------------------------------------|-------------------------------------------------------|----------|
+| <nobr>`project_id`</nobr>    | String | The Twingle project ID                             |                                                       | Yes      |
+| <nobr>`user_email`</nobr>    | String | The e-mail address of the contact                  | A valid e-mail address                                | Yes      |
+
+You may also refer to
+[the code](https://github.com/systopia/de.systopia.twingle/blob/master/api/v3/TwingleDonation/Doubleoptinconfirm.php)
 for more insight into this API action.

--- a/api/v3/TwingleDonation/Doubleoptinconfirm.php
+++ b/api/v3/TwingleDonation/Doubleoptinconfirm.php
@@ -1,0 +1,115 @@
+<?php
+/*------------------------------------------------------------+
+| SYSTOPIA Twingle Integration                                |
+| Copyright (C) 2018 SYSTOPIA                                 |
+| Author: J. Schuppe (schuppe@systopia.de)                    |
++-------------------------------------------------------------+
+| This program is released as free software under the         |
+| Affero GPL license. You can redistribute it and/or          |
+| modify it under the terms of this license which you         |
+| can read by viewing the included agpl.txt or online         |
+| at www.gnu.org/licenses/agpl.html. Removal of this          |
+| copyright header is strictly prohibited without             |
+| written permission from the original author(s).             |
++-------------------------------------------------------------*/
+
+use CRM_Twingle_ExtensionUtil as E;
+
+/**
+ * TwingleDonation.DoubleOptInConfirm API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $params description of fields supported by this API call
+ *
+ * @return void
+ *
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ */
+function _civicrm_api3_twingle_donation_DoubleOptInConfirm_spec(&$params)
+{
+    $params['project_id'] = array(
+        'name' => 'project_id',
+        'title' => E::ts('Project ID'),
+        'type' => CRM_Utils_Type::T_STRING,
+        'api.required' => 1,
+        'description' => E::ts('The Twingle project ID.'),
+    );
+    $params['user_email'] = array(
+        'name' => 'user_email',
+        'title' => E::ts('Email address'),
+        'type' => CRM_Utils_Type::T_STRING,
+        'api.required' => 1,
+        'description' => E::ts('The e-mail address of the contact.')
+    );
+}
+
+/**
+ * TwingleDonation.Cancel API
+ *
+ * @param array $params
+ * @return array API result descriptor
+ * @see civicrm_api3_create_success
+ * @see civicrm_api3_create_error
+ */
+function civicrm_api3_twingle_donation_DoubleOptInConfirm($params)
+{
+    // Log call if debugging is enabled within civicrm.settings.php.
+    if (defined('TWINGLE_API_LOGGING') && TWINGLE_API_LOGGING) {
+        CRM_Core_Error::debug_log_message('TwingleDonation.DoubleOptInConfirm: ' . json_encode($params, JSON_PRETTY_PRINT));
+    }
+
+    try {
+        // Get the profile defined for the given form ID, or the default profile
+        // if none matches.
+        $profile = CRM_Twingle_Profile::getProfileForProject($params['project_id']);
+
+        // Get the newsletter groups defined in the profile
+        $newsletter_groups = $profile->getAttribute('newsletter_groups');
+
+        // Extract user email from API call
+        if (!empty($params['user_email'])) {
+            $contacts = civicrm_api3('Email', 'get', array(
+                'seqential' => 1,
+                'email' => $params['user_email'],
+            ));
+
+            // Get pending group memberships for user
+            if (!empty($contacts['values'])) {
+                foreach ($contacts['values'] as $contact) {
+                    $groups = civicrm_api3('GroupContact', 'get', array(
+                        'sequential' => 1,
+                        'contact_id' => $contact['contact_id'],
+                        'status' => "Pending",
+                    ));
+
+                    // Only in newsletter groups: change group membership from pending to added
+                    if (!empty($groups['values'])) {
+                        foreach ($groups['values'] as $group) {
+                            if (in_array($group['group_id'], $newsletter_groups)) {
+                                civicrm_api3('GroupContact', 'create', array(
+                                    'group_id' => $group['group_id'],
+                                    'contact_id' => $contact['contact_id'],
+                                    'status' => "Added",
+                                    $result_values['groups'][] = $group['group_id'],
+                                ));
+                                // Display message if group membership was confirmed correctly
+                                $result_values['double_opt_in'][$group['group_id']] = "Subscription confirmed";
+                            }
+                        }
+                        // Display message if there is no pending group membership
+                    } else {
+                        $result_values['double_opt_in'][] = "Could not confirm subscription: No pending group membership";
+                    }
+                }
+                // Display message if email can't be found
+            } else {
+                $result_values['double_opt_in'][] = "Could not confirm subscription: Email not found";
+            }
+        }
+        $result = civicrm_api3_create_success($result_values);
+    } catch (Exception $exception) {
+        $result = civicrm_api3_create_error($exception->getMessage());
+    }
+
+    return $result;
+}

--- a/l10n/de_DE/LC_MESSAGES/twingle.po
+++ b/l10n/de_DE/LC_MESSAGES/twingle.po
@@ -306,3 +306,7 @@ msgstr "Profil %1 zurücksetzen"
 #: templates/CRM/Twingle/Page/Profiles.tpl
 msgid "Delete profile %1"
 msgstr "Profil % 1 löschen"
+
+#: templates/CRM/Twingle/Page/Profiles.tpl
+msgid "Use Twingle's Double-Opt-In procedure"
+msgstr "Nutze Twingles Double-Opt-In-Verfahren"

--- a/templates/CRM/Twingle/Form/Profile.tpl
+++ b/templates/CRM/Twingle/Form/Profile.tpl
@@ -209,6 +209,11 @@
       <table class="form-layout-compressed">
 
         <tr class="crm-section">
+          <td class="label">{$form.double_opt_in.label}</td>
+          <td class="content">{$form.double_opt_in.html}</td>
+        </tr>
+
+        <tr class="crm-section">
           <td class="label">{$form.newsletter_groups.label}</td>
           <td class="content">{$form.newsletter_groups.html}</td>
         </tr>

--- a/twingle.php
+++ b/twingle.php
@@ -151,6 +151,7 @@ function twingle_civicrm_alterAPIPermissions($entity, $action, &$params, &$permi
   $permissions['twingle_donation']['submit'] = array('access Twingle API');
   $permissions['twingle_donation']['cancel']  = array('access Twingle API');
   $permissions['twingle_donation']['endrecurring']  = array('access Twingle API');
+  $permissions['twingle_donation']['doubleoptinconfirm']  = array('access Twingle API');
 }
 
 // --- Functions below this ship commented out. Uncomment as required. ---


### PR DESCRIPTION
An implementation that permits the use of the Twingle Double-Opt-In procedure.

*TwingleManager:*
![TwingleManager_Double-Opt-In](https://user-images.githubusercontent.com/24728186/86020858-bb2d7c80-ba28-11ea-9bc9-7bbe761d5736.png) 

I added a new action [`DoubleOptInConfirm`](https://github.com/systopia/de.systopia.twingle/pull/35/commits/5ad7069abc2ff6c36e15558ea9bfb768af2e721e#diff-ed51f52c4bed4d99b807d9f05a719ec4) to the `TwingleDonation` entity.

The API call that Twingle would have to make should contain a JSON like this:
```JSON
{"project_id":"tw5e8b3bd4c2589","user_email":"dummy@contact.com"}
```
------------------
**Features**
- If the Double-Opt-In checkbox in the Twingle profile is ticked, a contact will be added to the newsletter groups with a pending state
- A contact which already is member of the newsletter group, won't get set back to pending 
------------------
fix #34 