### PR TITLE
Change campaign_id parameter data type and add validation for it

### DIFF
--- a/CRM/Twingle/Submission.php
+++ b/CRM/Twingle/Submission.php
@@ -117,6 +117,30 @@ class CRM_Twingle_Submission {
         );
       }
     }
+
+    // Validate campaign_id, if given.
+    if (!empty($params['campaign_id'])) {
+      // Check whether campaign_id is a numeric string and cast it to an integer.
+      if (is_numeric($params['campaign_id'])) {
+        $params['campaign_id'] = intval($params['campaign_id']);
+      }
+      else {
+        throw new CiviCRM_API3_Exception(
+          E::ts('campaign_id must be a numeric string. '),
+          'invalid_format'
+        );
+      }
+      // Check whether given campaign_id exists and if not, unset the parameter.
+      try {
+        civicrm_api3(
+          'Campaign',
+          'getsingle',
+          ['id' => $params['campaign_id']]
+        );
+      } catch (CiviCRM_API3_Exception $e) {
+        unset($params['campaign_id']);
+      }
+    }
   }
 
   /**

--- a/api/v3/TwingleDonation/Submit.php
+++ b/api/v3/TwingleDonation/Submit.php
@@ -234,7 +234,7 @@ function _civicrm_api3_twingle_donation_Submit_spec(&$params) {
   $params['campaign_id'] = array(
     'name' => 'campaign_id',
     'title' => E::ts('Campaign ID'),
-    'type' => CRM_Utils_Type::T_INT,
+    'type' => CRM_Utils_Type::T_STRING,
     'api.required' => 0,
     'description' => E::ts('The CiviCRM ID of a campaign to assign the contribution.'),
   );


### PR DESCRIPTION
This PR fixes #43 and #44 

Changes:
- changed `campaign_id` data type to string to fix #44 
- validate the `campaign_id` to fix #43
  - check the string to be numeric and throw an Exception (see below) if not
  - cast the numeric string to an integer
  - check if there is a campaign with the provided id and unset the `campaign_id` parameter if not
  
Exception:
```json
{
    "is_error": 1,
    "error_message": "campaign_id must be a numeric string. "
}
```