### PR TITLE
Update Profile.hlp

### DIFF
--- a/templates/CRM/Twingle/Form/Profile.hlp
+++ b/templates/CRM/Twingle/Form/Profile.hlp
@@ -58,6 +58,7 @@
     {ts domain="de.systopia.twingle"}<p>Map Twingle custom fields to CiviCRM custom fields using the following format (each assignment in a separate line):</p>
     <pre>twingle_field_1=custom_123<br />twingle_field_2=custom_789</pre>
     <p>Always use the <code>custom_[id]</code> notation for CiviCRM custom fields.</p>
+    <p>This only works for fields that Twingle itself provides in the custom_fields parameter, not for any parameters; i.e. user_extrafield always ends up in a note.</p>
     <p>Only custom fields extending one of the following CiviCRM entities are allowed:</p>
     <ul>
       <li><strong>Contact</strong> &ndash; Will be set on the Individual contact</li>


### PR DESCRIPTION
added information:
_This only works for fields that Twingle itself provides in the custom_fields parameter, not for any parameters; i.e. user_extrafield always ends up in a note._