### PR TITLE
Include purpose in custom_field_mapping

### DIFF
--- a/api/v3/TwingleDonation/Submit.php
+++ b/api/v3/TwingleDonation/Submit.php
@@ -304,10 +304,13 @@ function civicrm_api3_twingle_donation_Submit($params) {
     if (!empty($params['custom_fields'])) {
       $custom_field_mapping = $profile->getCustomFieldMapping();
 
-      // Include user_extrafield in custom_field_mapping if it is referenced there.
-      // See issue #50.
+      // Include user_extrafield and purpose in custom_field_mapping if it is
+      // referenced there. See issue #50.
       if(!empty($params['user_extrafield']) && isset($custom_field_mapping['user_extrafield'])) {
         $params['custom_fields']['user_extrafield'] = $params['user_extrafield'];
+      }
+      if(!empty($params['purpose']) && isset($custom_field_mapping['purpose'])) {
+        $params['custom_fields']['purpose'] = $params['purpose'];
       }
 
       foreach ($params['custom_fields'] as $twingle_field => $value) {


### PR DESCRIPTION
In #55 I did not include the "purpose" field. But as I found out in the meantime, it really makes sense to map this field as well. 😅

I have tested my change and it is already running on our production server.

close #50