### PR TITLE
Identify profiles by ID 

### DIFF
--- a/CRM/Twingle/Form/Profile.php
+++ b/CRM/Twingle/Form/Profile.php
@@ -640,6 +640,9 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
   public function setDefaultValues() {
     $defaults = parent::setDefaultValues();
     if (in_array($this->_op, ['create', 'edit', 'copy'])) {
+      if (!$this->profile) {
+        $this->profile = CRM_Twingle_Profile::createDefaultProfile()->copy();
+      }
       $defaults['name'] = $this->profile->getName();
       $profile_data = $this->profile->getData();
       foreach ($profile_data as $element_name => $value) {

--- a/CRM/Twingle/Form/Profile.php
+++ b/CRM/Twingle/Form/Profile.php
@@ -149,8 +149,7 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
     }
 
     // Verify that a profile with the given id exists.
-
-    if ($this->_op != 'copy') {
+    if ($this->_op != 'copy' && $this->_op != 'create') {
       $this->profile_id = CRM_Utils_Request::retrieve('id', 'Int', $this);
       $this->profile = CRM_Twingle_Profile::getProfile($this->profile_id);
     }

--- a/CRM/Twingle/Form/Profile.php
+++ b/CRM/Twingle/Form/Profile.php
@@ -160,7 +160,7 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
 
     switch ($this->_op) {
       case 'delete':
-        if ($this->profile_id) {
+        if ($this->profile) {
           CRM_Utils_System::setTitle(E::ts('Delete Twingle API profile <em>%1</em>', [1 => $this->profile->getName()]));
           $this->addButtons([
             [

--- a/CRM/Twingle/Form/Profile.php
+++ b/CRM/Twingle/Form/Profile.php
@@ -33,6 +33,12 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
   protected $profile;
 
   /**
+   * The ID of this profile.
+   * @var int|NULL
+   */
+  protected $profile_id = NULL;
+
+  /**
    * @var string
    *
    * The operation to perform within the form.
@@ -142,10 +148,11 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
       $this->_op = 'create';
     }
 
-    // Verify that a profile with the given name exists.
-    $profile_name = CRM_Utils_Request::retrieve('name', 'String', $this);
-    if (!$this->profile = CRM_Twingle_Profile::getProfile($profile_name)) {
-      $profile_name = NULL;
+    // Verify that a profile with the given id exists.
+
+    if ($this->_op != 'copy') {
+      $this->profile_id = CRM_Utils_Request::retrieve('id', 'Int', $this);
+      $this->profile = CRM_Twingle_Profile::getProfile($this->profile_id);
     }
 
     // Set redirect destination.
@@ -153,12 +160,12 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
 
     switch ($this->_op) {
       case 'delete':
-        if ($profile_name) {
-          CRM_Utils_System::setTitle(E::ts('Delete Twingle API profile <em>%1</em>', [1 => $profile_name]));
+        if ($this->profile_id) {
+          CRM_Utils_System::setTitle(E::ts('Delete Twingle API profile <em>%1</em>', [1 => $this->profile->getName()]));
           $this->addButtons([
             [
               'type' => 'submit',
-              'name' => ($profile_name == 'default' ? E::ts('Reset') : E::ts('Delete')),
+              'name' => ($this->profile->getName() == 'default' ? E::ts('Reset') : E::ts('Delete')),
               'isDefault' => TRUE,
             ],
           ]);
@@ -166,40 +173,37 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
         parent::buildQuickForm();
         return;
 
-      case 'edit':
-        // When editing without a valid profile name, edit the default profile.
-        if (!$profile_name) {
-          $profile_name = 'default';
-          $this->profile = CRM_Twingle_Profile::getProfile($profile_name);
-        }
-        CRM_Utils_System::setTitle(E::ts('Edit Twingle API profile <em>%1</em>', [1 => $this->profile->getName()]));
-        break;
-
       case 'copy':
         // Retrieve the source profile name.
-        $profile_name = CRM_Utils_Request::retrieve('source_name', 'String', $this);
-        // When copying without a valid profile name, copy the default profile.
-        if (!$profile_name) {
-          $profile_name = 'default';
+        $source_id = CRM_Utils_Request::retrieve('source_id', 'Int', $this);
+        // When copying without a valid profile id, copy the default profile.
+        if (!$source_id) {
+          $this->profile = CRM_Twingle_Profile::createDefaultProfile();
+        } else {
+          $source_profile = CRM_Twingle_Profile::getProfile($source_id);
+          $this->profile = $source_profile->copy();
         }
-        $this->profile = clone CRM_Twingle_Profile::getProfile($profile_name);
-
         // Propose a new name for this profile.
-        $profile_name = $profile_name . '_copy';
+        $profile_name = $this->profile->getName() . '_copy';
         $this->profile->setName($profile_name);
         CRM_Utils_System::setTitle(E::ts('New Twingle API profile'));
         break;
 
+      case 'edit':
+        CRM_Utils_System::setTitle(E::ts('Edit Twingle API profile <em>%1</em>', [1 => $this->profile->getName()]));
+        break;
+
       case 'create':
         // Load factory default profile values.
-        $this->profile = CRM_Twingle_Profile::createDefaultProfile($profile_name);
+        $this->profile = CRM_Twingle_Profile::createDefaultProfile(E::ts('New Profile'));
         CRM_Utils_System::setTitle(E::ts('New Twingle API profile'));
         break;
     }
 
     // Assign template variables.
     $this->assign('op', $this->_op);
-    $this->assign('profile_name', $profile_name);
+    $this->assign('profile_name', $this->profile->getName());
+    $this->assign('is_default', $this->profile->is_default());
 
     // Add form elements.
     $is_default = $profile_name == 'default';

--- a/CRM/Twingle/Form/Settings.php
+++ b/CRM/Twingle/Form/Settings.php
@@ -25,7 +25,8 @@ use CRM_Twingle_ExtensionUtil as E;
 class CRM_Twingle_Form_Settings extends CRM_Core_Form {
 
   /**
-   * @var arraylistofallsettingsoptions
+   * @var array<string>
+   *   List of all settings options.
    */
   public static $SETTINGS_LIST = [
     'twingle_prefix',
@@ -133,7 +134,8 @@ class CRM_Twingle_Form_Settings extends CRM_Core_Form {
     // if activity creation is active, make sure the fields are set
     $protection_mode = CRM_Utils_Array::value('twingle_protect_recurring', $this->_submitValues);
     if ($protection_mode == CRM_Twingle_Config::RCUR_PROTECTION_ACTIVITY) {
-      foreach (['twingle_protect_recurring_activity_type',
+      foreach ([
+        'twingle_protect_recurring_activity_type',
         'twingle_protect_recurring_activity_subject',
         'twingle_protect_recurring_activity_status',
         'twingle_protect_recurring_activity_assignee',

--- a/CRM/Twingle/Page/Profiles.php
+++ b/CRM/Twingle/Page/Profiles.php
@@ -22,10 +22,11 @@ class CRM_Twingle_Page_Profiles extends CRM_Core_Page {
   public function run() {
     CRM_Utils_System::setTitle(E::ts('Twingle API Profiles'));
     $profiles = [];
-    foreach (CRM_Twingle_Profile::getProfiles() as $profile_name => $profile) {
-      $profiles[$profile_name]['name'] = $profile_name;
+    foreach (CRM_Twingle_Profile::getProfiles() as $profile_id => $profile) {
+      $profiles[$profile_id]['id'] = $profile_id;
+      $profiles[$profile_id]['name'] = $profile->getName();
       foreach (CRM_Twingle_Profile::allowedAttributes() as $attribute) {
-        $profiles[$profile_name][$attribute] = $profile->getAttribute($attribute);
+        $profiles[$profile_id][$attribute] = $profile->getAttribute($attribute);
       }
     }
     $this->assign('profiles', $profiles);

--- a/CRM/Twingle/Profile.php
+++ b/CRM/Twingle/Profile.php
@@ -298,7 +298,7 @@ class CRM_Twingle_Profile {
       } catch (Exception $e) {
         throw new ProfileException(
           E::ts("Could not delete profile: %1", [1 => $e->getMessage()]),
-          ProfileException::ERROR_CODE_COULD_NOT_RESET_PROFILE
+          ProfileException::ERROR_CODE_COULD_NOT_DELETE_PROFILE
         );
       }
     }

--- a/CRM/Twingle/Profile.php
+++ b/CRM/Twingle/Profile.php
@@ -235,10 +235,11 @@ class CRM_Twingle_Profile {
       if ($this->id !== NULL) {
         // existing profile -> just update the config
         CRM_Core_DAO::executeQuery(
-          "UPDATE civicrm_twingle_profile SET config = %2 WHERE id = %1",
+          "UPDATE civicrm_twingle_profile SET config = %2, name = %3 WHERE id = %1",
           [
             1 => [$this->id, 'String'],
             2 => [json_encode($this->data), 'String'],
+            3 => [$this->name, 'String'],
           ]);
       }
       else {

--- a/CRM/Twingle/Profile.php
+++ b/CRM/Twingle/Profile.php
@@ -25,7 +25,13 @@ use Civi\Twingle\Exceptions\ProfileException as ProfileException;
 class CRM_Twingle_Profile {
 
   /**
-   * @var string
+   * @var int $id
+   *   The id of the profile.
+   */
+  protected $id = NULL;
+
+  /**
+   * @var string $name
    *   The name of the profile.
    */
   protected $name = NULL;
@@ -43,8 +49,10 @@ class CRM_Twingle_Profile {
    *   The name of the profile.
    * @param array $data
    *   The properties of the profile
+   * @param int|NULL $id
    */
-  public function __construct($name, $data) {
+  public function __construct($name, $data, $id = NULL) {
+    $this->id = $id;
     $this->name = $name;
     $allowed_attributes = self::allowedAttributes();
     $this->data = $data + array_combine(
@@ -63,6 +71,18 @@ class CRM_Twingle_Profile {
             last_access = NOW(),
             access_counter = access_counter + 1
         WHERE name = %1', [1 => [$this->name, 'String']]);
+  }
+
+  /**
+   * Copy this profile by returning a clone with all unique information removed.
+   *
+   * @return CRM_Twingle_Profile
+   */
+  public function copy() {
+    $copy = clone $this;
+    $copy->id = NULL;
+    $copy->data['selector'] = NULL;
+    return $copy;
   }
 
   /**
@@ -108,6 +128,24 @@ class CRM_Twingle_Profile {
   }
 
   /**
+   * Retrieves the profile id.
+   *
+   * @return int
+   */
+  public function getId() {
+    return $this->id;
+  }
+
+  /**
+   * Set the profile id.
+   *
+   * @param int $id
+   */
+  public function setId(int $id) {
+    $this->id = $id;
+  }
+
+  /**
    * Retrieves the profile name.
    *
    * @return string
@@ -119,9 +157,9 @@ class CRM_Twingle_Profile {
   /**
    * Sets the profile name.
    *
-   * @param $name
+   * @param string $name
    */
-  public function setName($name) {
+  public function setName(string $name) {
     $this->name = $name;
   }
 
@@ -193,37 +231,76 @@ class CRM_Twingle_Profile {
     // make sure it's valid
     $this->verifyProfile();
 
-    // check if the profile exists
-    $profile_id = CRM_Core_DAO::singleValueQuery(
-      'SELECT id FROM civicrm_twingle_profile WHERE name = %1', [1 => [$this->name, 'String']]);
-    if ($profile_id) {
-      // existing profile -> just update the config
-      CRM_Core_DAO::executeQuery(
-        'UPDATE civicrm_twingle_profile SET config = %2 WHERE name = %1',
-        [
-          1 => [$this->name, 'String'],
-          2 => [json_encode($this->data), 'String'],
-        ]);
+    try {
+      if ($this->id !== NULL) {
+        // existing profile -> just update the config
+        CRM_Core_DAO::executeQuery(
+          "UPDATE civicrm_twingle_profile SET config = %2 WHERE id = %1",
+          [
+            1 => [$this->id, 'String'],
+            2 => [json_encode($this->data), 'String'],
+          ]);
+      }
+      else {
+        // new profile -> add new entry to the DB
+        CRM_Core_DAO::executeQuery(
+          "INSERT IGNORE INTO civicrm_twingle_profile(name,config,last_access,access_counter) VALUES (%1, %2, null, 0)",
+          [
+            1 => [$this->name, 'String'],
+            2 => [json_encode($this->data), 'String'],
+          ]);
+      }
     }
-    else {
-      // new profile -> add new entry to the DB
-      CRM_Core_DAO::executeQuery(
-        'INSERT IGNORE INTO civicrm_twingle_profile(name,config,last_access,access_counter) VALUES (%1, %2, null, 0)',
-        [
-          1 => [$this->name, 'String'],
-          2 => [json_encode($this->data), 'String'],
-        ]);
+    catch (Exception $e) {
+      throw new ProfileException(
+        E::ts("Could not save/update profile: %1", [1 => $e->getMessage()]),
+        ProfileException::ERROR_CODE_COULD_NOT_SAVE_PROFILE
+      );
     }
   }
 
   /**
    * Deletes the profile from the database
+   *
+   * @throws \CRM_Twingle_Exceptions_ProfileException
    */
   public function deleteProfile() {
-    CRM_Core_DAO::executeQuery(
-      'DELETE FROM civicrm_twingle_profile WHERE name = %1',
-      [1 => [$this->name, 'String']]
-    );
+    // Do only reset default profile
+    if ($this->getName() == 'default') {
+      try {
+        $default_profile = CRM_Twingle_Profile::createDefaultProfile();
+        $default_profile->setId($this->getId());
+        $default_profile->saveProfile();
+
+        // Reset counter
+        CRM_Core_DAO::executeQuery("UPDATE civicrm_twingle_profile SET access_counter = 0, last_access = NULL WHERE id = %1", [
+          1 => [
+            $this->id,
+            'Integer'
+          ]
+        ]);
+      } catch (Exception $e) {
+        throw new ProfileException(
+          E::ts("Could not reset default profile: %1", [1 => $e->getMessage()]),
+          ProfileException::ERROR_CODE_COULD_NOT_RESET_PROFILE
+        );
+      }
+    }
+    else {
+      try {
+        CRM_Core_DAO::executeQuery("DELETE FROM civicrm_twingle_profile WHERE id = %1", [
+          1 => [
+            $this->id,
+            'Integer'
+          ]
+        ]);
+      } catch (Exception $e) {
+        throw new ProfileException(
+          E::ts("Could not delete profile: %1", [1 => $e->getMessage()]),
+          ProfileException::ERROR_CODE_COULD_NOT_RESET_PROFILE
+        );
+      }
+    }
   }
 
   /**
@@ -305,9 +382,9 @@ class CRM_Twingle_Profile {
    */
   public static function createDefaultProfile($name = 'default') {
     return new CRM_Twingle_Profile($name, [
-      'selector' => '',
-      'xcm_profile' => '',
-      'location_type_id' => CRM_Twingle_Submission::LOCATION_TYPE_ID_WORK,
+      'selector'          => NULL,
+      'xcm_profile'       => '',
+      'location_type_id'  => CRM_Twingle_Submission::LOCATION_TYPE_ID_WORK,
       'location_type_id_organisation' => CRM_Twingle_Submission::LOCATION_TYPE_ID_WORK,
       // "Donation"
       'financial_type_id' => 1,
@@ -391,20 +468,19 @@ class CRM_Twingle_Profile {
   }
 
   /**
-   * Retrieves the profile with the given name.
+   * Retrieves the profile with the given ID.
    *
-   * @param string $name
+   * @param int|NULL $id
    *
    * @return CRM_Twingle_Profile | NULL
+   * @throws \Civi\Core\Exception\DBQueryException
    */
-  public static function getProfile($name) {
-    if (!empty($name)) {
-      $profile_data = CRM_Core_DAO::singleValueQuery(
-        'SELECT config FROM civicrm_twingle_profile WHERE name = %1',
-        [1 => [$name, 'String']]
-      );
-      if ($profile_data) {
-        return new CRM_Twingle_Profile($name, json_decode($profile_data, 1));
+  public static function getProfile(int $id = NULL) {
+    if (!empty($id)) {
+      $profile_data = CRM_Core_DAO::executeQuery("SELECT id, name, config FROM civicrm_twingle_profile WHERE id = %1",
+        [1 => [$id, 'Integer']]);
+      if ($profile_data->fetch()) {
+        return new CRM_Twingle_Profile($profile_data->name, json_decode($profile_data->config, 1), (int) $profile_data->id);
       }
     }
     return NULL;
@@ -416,16 +492,14 @@ class CRM_Twingle_Profile {
    *
    * @return array
    *   profile_name => CRM_Twingle_Profile
+   * @throws \Civi\Core\Exception\DBQueryException
    */
   public static function getProfiles() {
     // todo: cache?
     $profiles = [];
-    $profile_data = CRM_Core_DAO::executeQuery('SELECT name, config FROM civicrm_twingle_profile');
+    $profile_data = CRM_Core_DAO::executeQuery("SELECT id, name, config FROM civicrm_twingle_profile");
     while ($profile_data->fetch()) {
-      $profiles[$profile_data->name] = new CRM_Twingle_Profile(
-        $profile_data->name,
-        json_decode($profile_data->config, 1)
-      );
+      $profiles[$profile_data->id] = new CRM_Twingle_Profile($profile_data->name, json_decode($profile_data->config, 1), (int) $profile_data->id);
     }
     return $profiles;
   }

--- a/CRM/Twingle/Profile.php
+++ b/CRM/Twingle/Profile.php
@@ -221,7 +221,7 @@ class CRM_Twingle_Profile {
    * Verifies whether the profile is valid (i.e. consistent and not colliding
    * with other profiles).
    *
-   * @throws \CRM\Twingle\Exceptions\ProfileValidationError
+   * @throws \Civi\Twingle\Exceptions\ProfileValidationError
    * @throws \Civi\Core\Exception\DBQueryException
    *   When the profile could not be successfully validated.
    */
@@ -234,7 +234,7 @@ class CRM_Twingle_Profile {
   /**
    * Persists the profile within the database.
    *
-   * @throws \CRM\Twingle\Exceptions\ProfileException
+   * @throws \Civi\Twingle\Exceptions\ProfileException
    */
   public function saveProfile() {
     // make sure it's valid
@@ -272,7 +272,7 @@ class CRM_Twingle_Profile {
   /**
    * Deletes the profile from the database
    *
-   * @throws \CRM\Twingle\Exceptions\ProfileException
+   * @throws \Civi\Twingle\Exceptions\ProfileException
    */
   public function deleteProfile() {
     // Do only reset default profile
@@ -484,7 +484,7 @@ class CRM_Twingle_Profile {
    *
    * @return CRM_Twingle_Profile | NULL
    * @throws \Civi\Core\Exception\DBQueryException
-   * @throws \CRM\Twingle\Exceptions\ProfileException
+   * @throws \Civi\Twingle\Exceptions\ProfileException
    */
   public static function getProfile(int $id = NULL) {
     if (!empty($id)) {

--- a/CRM/Twingle/Profile.php
+++ b/CRM/Twingle/Profile.php
@@ -80,8 +80,14 @@ class CRM_Twingle_Profile {
    */
   public function copy() {
     $copy = clone $this;
+
+    // Remove unique data
     $copy->id = NULL;
     $copy->data['selector'] = NULL;
+
+    // Propose a new name for this profile.
+    $profile_name = $this->getName() . '_copy';
+    $copy->setName($profile_name);
     return $copy;
   }
 
@@ -484,7 +490,7 @@ class CRM_Twingle_Profile {
         return new CRM_Twingle_Profile($profile_data->name, json_decode($profile_data->config, 1), (int) $profile_data->id);
       }
     }
-    return NULL;
+    throw new ProfileException('Profile not found.', ProfileException::ERROR_CODE_PROFILE_NOT_FOUND);
   }
 
   /**

--- a/CRM/Twingle/Profile.php
+++ b/CRM/Twingle/Profile.php
@@ -221,7 +221,8 @@ class CRM_Twingle_Profile {
    * Verifies whether the profile is valid (i.e. consistent and not colliding
    * with other profiles).
    *
-   * @throws Exception
+   * @throws \CRM\Twingle\Exceptions\ProfileValidationError
+   * @throws \Civi\Core\Exception\DBQueryException
    *   When the profile could not be successfully validated.
    */
   public function verifyProfile() {
@@ -231,7 +232,9 @@ class CRM_Twingle_Profile {
   }
 
   /**
-   * Persists the profile within the CiviCRM settings.
+   * Persists the profile within the database.
+   *
+   * @throws \CRM\Twingle\Exceptions\ProfileException
    */
   public function saveProfile() {
     // make sure it's valid
@@ -269,7 +272,7 @@ class CRM_Twingle_Profile {
   /**
    * Deletes the profile from the database
    *
-   * @throws \CRM_Twingle_Exceptions_ProfileException
+   * @throws \CRM\Twingle\Exceptions\ProfileException
    */
   public function deleteProfile() {
     // Do only reset default profile
@@ -481,6 +484,7 @@ class CRM_Twingle_Profile {
    *
    * @return CRM_Twingle_Profile | NULL
    * @throws \Civi\Core\Exception\DBQueryException
+   * @throws \CRM\Twingle\Exceptions\ProfileException
    */
   public static function getProfile(int $id = NULL) {
     if (!empty($id)) {

--- a/templates/CRM/Twingle/Page/Profiles.tpl
+++ b/templates/CRM/Twingle/Page/Profiles.tpl
@@ -33,6 +33,7 @@
       </thead>
       <tbody>
       {foreach from=$profiles item=profile}
+        {assign var="profile_id" value=$profile.id}
         {assign var="profile_name" value=$profile.name}
         <tr>
           <td>{$profile.name}</td>
@@ -42,12 +43,12 @@
           <td>{ts domain="de.systopia.twingle"}{$profile_stats.$profile_name.access_counter_txt}{/ts}</td>
           <td>{ts domain="de.systopia.twingle"}{$profile_stats.$profile_name.last_access_txt}{/ts}</td>
           <td>
-            <a href="{crmURL p="civicrm/admin/settings/twingle/profile" q="op=edit&name=$profile_name"}" title="{ts domain="de.systopia.twingle" 1=$profile.name}Edit profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.twingle"}Edit{/ts}</a>
-            <a href="{crmURL p="civicrm/admin/settings/twingle/profile" q="op=copy&source_name=$profile_name"}" title="{ts domain="de.systopia.twingle" 1=$profile.name}Copy profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.twingle"}Copy{/ts}</a>
+            <a href="{crmURL p="civicrm/admin/settings/twingle/profile" q="op=edit&id=$profile_id"}" title="{ts domain="de.systopia.twingle" 1=$profile.name}Edit profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.twingle"}Edit{/ts}</a>
+            <a href="{crmURL p="civicrm/admin/settings/twingle/profile" q="op=copy&source_id=$profile_id"}" title="{ts domain="de.systopia.twingle" 1=$profile.name}Copy profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.twingle"}Copy{/ts}</a>
             {if $profile_name == 'default'}
-              <a href="{crmURL p="civicrm/admin/settings/twingle/profile" q="op=delete&name=$profile_name"}" title="{ts domain="de.systopia.twingle" 1=$profile.name}Reset profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.twingle"}Reset{/ts}</a>
+              <a href="{crmURL p="civicrm/admin/settings/twingle/profile" q="op=delete&id=$profile_id"}" title="{ts domain="de.systopia.twingle" 1=$profile.name}Reset profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.twingle"}Reset{/ts}</a>
             {else}
-              <a href="{crmURL p="civicrm/admin/settings/twingle/profile" q="op=delete&name=$profile_name"}" title="{ts domain="de.systopia.twingle" 1=$profile.name}Delete profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.twingle"}Delete{/ts}</a>
+              <a href="{crmURL p="civicrm/admin/settings/twingle/profile" q="op=delete&id=$profile_id"}" title="{ts domain="de.systopia.twingle" 1=$profile.name}Delete profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.twingle"}Delete{/ts}</a>
             {/if}
 
           </td>


### PR DESCRIPTION
Storing profiles in a separate db table instead of native CiviCRM settings was implemented in fd47b91b65cd1e6acf3387b642678abfbcd1e079. 

Nevertheless, the name of the profile is still used to identify it. This leads to problems like #70.

I have now implemented the identification of profiles by their database ID.

**This PR depends on PR #72 because it uses the custom `ProfileException` class!**