### PR TITLE
Improve default profile behavior

### DIFF
--- a/CRM/Twingle/Form/Profile.php
+++ b/CRM/Twingle/Form/Profile.php
@@ -194,24 +194,27 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
     // Assign template variables.
     $this->assign('op', $this->_op);
     $this->assign('profile_name', $profile_name);
+    $this->assign('is_default', $this->profile->is_default());
 
     // Add form elements.
-    $is_default = $profile_name == 'default';
-    $this->add(
-      ($is_default ? 'static' : 'text'),
-      'name',
-      E::ts('Profile name'),
-      array(),
-      !$is_default
-    );
-
     $this->add(
       'text', // field type
-      'selector', // field name
-      E::ts('Project IDs'), // field label
-      ['class' => 'huge'],
-      TRUE // is required
+      'name', // field name
+      E::ts('Profile name'),
+      ['class' => 'huge'] + ($this->profile->is_default() && $this->_op == 'edit' ? ['readonly'] : []),
+      !$this->profile->is_default()
     );
+
+    // Do only display selector if this is not the default profile
+    if (!$this->profile->is_default()) {
+      $this->add(
+        'text', // field type
+        'selector', // field name
+        E::ts('Project IDs'), // field label
+        ['class' => 'huge'],
+        TRUE // is required
+      );
+    }
 
     $this->add(
         'select',

--- a/CRM/Twingle/Form/Profile.php
+++ b/CRM/Twingle/Form/Profile.php
@@ -191,22 +191,25 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
         break;
     }
 
+    // Is this the default profile?
+    $is_default = $this->profile->is_default();
+
     // Assign template variables.
     $this->assign('op', $this->_op);
     $this->assign('profile_name', $profile_name);
-    $this->assign('is_default', $this->profile->is_default());
+    $this->assign('is_default', $is_default);
 
     // Add form elements.
     $this->add(
       'text', // field type
       'name', // field name
       E::ts('Profile name'),
-      ['class' => 'huge'] + ($this->profile->is_default() && $this->_op == 'edit' ? ['readonly'] : []),
-      !$this->profile->is_default()
+      ['class' => 'huge'] + ($is_default && $this->_op == 'edit' ? ['readonly'] : []),
+      !$is_default
     );
 
     // Do only display selector if this is not the default profile
-    if (!$this->profile->is_default()) {
+    if (!$is_default) {
       $this->add(
         'text', // field type
         'selector', // field name

--- a/CRM/Twingle/Page/Profiles.php
+++ b/CRM/Twingle/Page/Profiles.php
@@ -20,8 +20,10 @@ class CRM_Twingle_Page_Profiles extends CRM_Core_Page {
   public function run() {
     CRM_Utils_System::setTitle(E::ts("Twingle API Profiles"));
     $profiles = [];
-    foreach (CRM_Twingle_Profile::getProfiles() as $profile_name => $profile) {
-      $profiles[$profile_name]['name'] = $profile_name;
+    foreach (CRM_Twingle_Profile::getProfiles() as $profile_id => $profile) {
+      $profiles[$profile_id]['id'] = $profile_id;
+      $profiles[$profile_id]['name'] = $profile->getName();
+      $profiles[$profile_id]['is_default'] = $profile->is_default();
       foreach (CRM_Twingle_Profile::allowedAttributes() as $attribute) {
         $profiles[$profile_name][$attribute] = $profile->getAttribute($attribute);
       }

--- a/CRM/Twingle/Page/Profiles.php
+++ b/CRM/Twingle/Page/Profiles.php
@@ -25,7 +25,7 @@ class CRM_Twingle_Page_Profiles extends CRM_Core_Page {
       $profiles[$profile_id]['name'] = $profile->getName();
       $profiles[$profile_id]['is_default'] = $profile->is_default();
       foreach (CRM_Twingle_Profile::allowedAttributes() as $attribute) {
-        $profiles[$profile_name][$attribute] = $profile->getAttribute($attribute);
+        $profiles[$profile_id][$attribute] = $profile->getAttribute($attribute);
       }
     }
     $this->assign('profiles', $profiles);

--- a/CRM/Twingle/Profile.php
+++ b/CRM/Twingle/Profile.php
@@ -125,6 +125,15 @@ class CRM_Twingle_Profile {
   }
 
   /**
+   * Is this the default profile?
+   *
+   * @return bool
+   */
+  public function is_default() {
+    return $this->name == 'default';
+  }
+
+  /**
    * Retrieves an attribute of the profile.
    *
    * @param string $attribute_name
@@ -359,18 +368,29 @@ class CRM_Twingle_Profile {
    * @param $project_id
    *
    * @return CRM_Twingle_Profile
+   * @throws \CRM_Twingle_Exceptions_ProfileException
+   * @throws \Civi\Core\Exception\DBQueryException
    */
   public static function getProfileForProject($project_id) {
     $profiles = self::getProfiles();
+    $default_profile = NULL;
 
     foreach ($profiles as $profile) {
       if ($profile->matches($project_id)) {
         return $profile;
       }
+      if ($profile->is_default()) {
+        $default_profile = $profile;
+      }
     }
 
     // If none matches, use the default profile.
-    return $profiles['default'];
+    if (!empty($default_profile)) {
+      return $default_profile;
+    }
+    else {
+      throw new ProfileException('Could not find default profile', ProfileException::ERROR_CODE_DEFAULT_PROFILE_NOT_FOUND);
+    }
   }
 
   /**

--- a/templates/CRM/Twingle/Form/Profile.tpl
+++ b/templates/CRM/Twingle/Form/Profile.tpl
@@ -28,6 +28,7 @@
         </tr>
 
         <tr class="crm-section">
+          {if not $form.is_default}
           <td class="label">{$form.selector.label}
             <a
                     onclick='
@@ -46,6 +47,7 @@
             ></a>
           </td>
           <td class="content">{$form.selector.html}</td>
+          {/if}
         </tr>
 
         <tr class="crm-section">


### PR DESCRIPTION
The _Project IDs_ field should not be displayed in the default profile and it should not be required for saving. The only way to make changes to the default profile so far was to use a dummy project ID like `twxxxxxxxx`. Therefore, I have removed this field in the default profile.

I have also changed the name field in the default profile to a non-editable form field instead of static text. 

**This PR depends on PRs #72 and #73 because it uses the custom `ProfileException` class and refers to profiles by their ID instead their name!**