### PR TITLE
Improve profile validation

### DIFF
--- a/CRM/Twingle/Form/Profile.php
+++ b/CRM/Twingle/Form/Profile.php
@@ -16,8 +16,9 @@
 declare(strict_types = 1);
 
 use CRM_Twingle_ExtensionUtil as E;
-use Civi\Twingle\Exceptions\ProfileException;
 use Civi\Twingle\Exceptions\BaseException;
+use Civi\Twingle\Exceptions\ProfileException;
+use Civi\Twingle\Exceptions\ProfileValidationError;
 
 /**
  * Form controller class
@@ -168,7 +169,7 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
 
     switch ($this->_op) {
       case 'delete':
-        if ($this->profile) {
+        if (isset($this->profile)) {
           CRM_Utils_System::setTitle(E::ts('Delete Twingle API profile <em>%1</em>', [1 => $this->profile->getName()]));
           $this->addButtons([
             [
@@ -185,23 +186,26 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
         // Retrieve the source profile name.
         $source_id = CRM_Utils_Request::retrieve('source_id', 'Int', $this);
         // When copying without a valid profile id, copy the default profile.
-        if (!$source_id) {
+        if (!is_int($source_id)) {
           $this->profile = CRM_Twingle_Profile::createDefaultProfile();
-        } else {
+        }
+        else {
           try {
             $source_profile = CRM_Twingle_Profile::getProfile($source_id);
             $this->profile = $source_profile->copy();
             $this->profile->validate();
-          } catch (ProfileValidationError $e) {
-            if ($e->getErrorCode() == ProfileValidationError::ERROR_CODE_PROFILE_VALIDATION_FAILED) {
-              Civi::log()->error($e->getLogMessage());
+          }
+          catch (ProfileValidationError $exception) {
+            if ($exception->getErrorCode() == ProfileValidationError::ERROR_CODE_PROFILE_VALIDATION_FAILED) {
+              Civi::log()->error($exception->getLogMessage());
               CRM_Core_Session::setStatus(E::ts('The profile is invalid and cannot be copied.'), E::ts('Error'));
               CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/admin/settings/twingle/profiles', 'reset=1'));
               return;
             }
-          } catch (ProfileException $e) {
-            if ($e->getErrorCode() == ProfileException::ERROR_CODE_PROFILE_NOT_FOUND) {
-              Civi::log()->error($e->getLogMessage());
+          }
+          catch (ProfileException $exception) {
+            if ($exception->getErrorCode() == ProfileException::ERROR_CODE_PROFILE_NOT_FOUND) {
+              Civi::log()->error($exception->getLogMessage());
               CRM_Core_Session::setStatus(E::ts('The profile to be copied could not be found.'), E::ts('Error'));
               CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/admin/settings/twingle/profiles', 'reset=1'));
               return;
@@ -209,7 +213,10 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
           }
           catch (Civi\Core\Exception\DBQueryException $e) {
             Civi::log()->error($e->getMessage());
-            CRM_Core_Session::setStatus(E::ts('A database error has occurred. See the log for details.'), E::ts('Error'));
+            CRM_Core_Session::setStatus(
+              E::ts('A database error has occurred. See the log for details.'),
+              E::ts('Error')
+            );
             CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/admin/settings/twingle/profiles', 'reset=1'));
             return;
           }
@@ -218,7 +225,9 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
         break;
 
       case 'edit':
-        CRM_Utils_System::setTitle(E::ts('Edit Twingle API profile <em>%1</em>', [1 => $this->profile->getName()]));
+        CRM_Utils_System::setTitle(
+          E::ts('Edit Twingle API profile <em>%1</em>', [1 => $this->profile->getName()])
+        );
         break;
 
       case 'create':
@@ -554,8 +563,8 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
    */
   public function validate() {
 
-    if (in_array($this->_op, ['create', 'edit', 'copy'])) {
-      // Create profile with new values
+    if (in_array($this->_op, ['create', 'edit', 'copy'], TRUE)) {
+      // Create profile with new values.
       $profile_values = $this->exportValues();
       $profile = new CRM_Twingle_Profile(
         $profile_values['name'],
@@ -572,6 +581,7 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
           case ProfileValidationError::ERROR_CODE_PROFILE_VALIDATION_FAILED:
             $this->setElementError($e->getAffectedFieldName(), $e->getMessage());
             break;
+
           case ProfileValidationError::ERROR_CODE_PROFILE_VALIDATION_WARNING:
             CRM_Core_Session::setStatus($e->getMessage(), E::ts('Warning'));
         }

--- a/CRM/Twingle/Form/Profile.php
+++ b/CRM/Twingle/Form/Profile.php
@@ -568,7 +568,13 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
         $profile->validate();
       }
       catch (ProfileValidationError $e) {
-        $this->setElementError($e->getAffectedFieldName(), $e->getMessage());
+        switch ($e->getErrorCode()) {
+          case ProfileValidationError::ERROR_CODE_PROFILE_VALIDATION_FAILED:
+            $this->setElementError($e->getAffectedFieldName(), $e->getMessage());
+            break;
+          case ProfileValidationError::ERROR_CODE_PROFILE_VALIDATION_WARNING:
+            CRM_Core_Session::setStatus($e->getMessage(), E::ts('Warning'));
+        }
       }
     }
 

--- a/CRM/Twingle/Profile.php
+++ b/CRM/Twingle/Profile.php
@@ -296,7 +296,7 @@ class CRM_Twingle_Profile {
               2 => $profile->getName()
             ]
           ),
-          ProfileValidationError::ERROR_CODE_PROFILE_VALIDATION_FAILED
+          ProfileValidationError::ERROR_CODE_PROFILE_VALIDATION_WARNING
         );
       }
     }

--- a/Civi/Twingle/Exceptions/BaseException.php
+++ b/Civi/Twingle/Exceptions/BaseException.php
@@ -28,21 +28,21 @@ use CRM_Twingle_ExtensionUtil as E;
 class BaseException extends \Exception {
 
   /**
-   * @var int|string
+   * @var string
    */
   protected $code;
   protected string $log_message;
 
   /**
    * BaseException Constructor
-   * @param string|null $message
+   * @param string $message
    *   Error message
-   * @param string|null $error_code
+   * @param string $error_code
    *   A meaningful error code
-   * @param \Throwable|null $previous
+   * @param \Throwable $previous
    *   A previously thrown exception to include.
    */
-  public function __construct(?string $message = '', ?string $error_code = '', ?\Throwable $previous = NULL) {
+  public function __construct(string $message = '', string $error_code = '', \Throwable $previous = NULL) {
     parent::__construct($message, 1, $previous);
     $this->log_message = '' !== $message ? E::LONG_NAME . ': ' . $message : '';
     $this->code = $error_code;
@@ -61,7 +61,7 @@ class BaseException extends \Exception {
    * @return string
    */
   public function getErrorCode() {
-    return (string) $this->code;
+    return $this->code;
   }
 
 }

--- a/Civi/Twingle/Exceptions/ProfileValidationError.php
+++ b/Civi/Twingle/Exceptions/ProfileValidationError.php
@@ -38,8 +38,13 @@ class ProfileValidationError extends BaseException {
    * @param string $error_code
    *  A meaningful error code
    */
-  public function __construct(string $affected_field_name, string $message = '', string $error_code = '') {
-    parent::__construct($message, $error_code);
+  public function __construct(
+    string $affected_field_name,
+    string $message = '',
+    string $error_code = '',
+    ?\Throwable $previous = NULL
+  ) {
+    parent::__construct($message, $error_code, $previous);
     $this->affected_field_name = $affected_field_name;
   }
 


### PR DESCRIPTION
I moved the whole profile validation into the `CRM_Twingle_Profile` class. I also added some new checks for:
- empty profile names
- duplicate profile names
- duplicate project identifiers (selectors)

Spaces are now allowed in profile names.

**This PR depends on PRs #72 and #73 because custom `ProfileValidationError` class is used and profiles are referred to by their id!**