### PR TITLE
Improve profile list view

### DIFF
--- a/CRM/Twingle/Page/Profiles.php
+++ b/CRM/Twingle/Page/Profiles.php
@@ -32,6 +32,9 @@ class CRM_Twingle_Page_Profiles extends CRM_Core_Page {
     $this->assign('profiles', $profiles);
     $this->assign('profile_stats', CRM_Twingle_Profile::getProfileStats());
 
+    // Add custom css
+    Civi::resources()->addStyleFile(E::LONG_NAME, 'css/twingle.css');
+
     parent::run();
   }
 

--- a/CRM/Twingle/Page/Profiles.php
+++ b/CRM/Twingle/Page/Profiles.php
@@ -20,8 +20,11 @@ class CRM_Twingle_Page_Profiles extends CRM_Core_Page {
   public function run() {
     CRM_Utils_System::setTitle(E::ts("Twingle API Profiles"));
     $profiles = [];
-    foreach (CRM_Twingle_Profile::getProfiles() as $profile_name => $profile) {
-      $profiles[$profile_name]['name'] = $profile_name;
+    foreach (CRM_Twingle_Profile::getProfiles() as $profile_id => $profile) {
+      $profiles[$profile_id]['id'] = $profile_id;
+      $profiles[$profile_id]['name'] = $profile->getName();
+      $profiles[$profile_id]['is_default'] = $profile->is_default();
+      $profiles[$profile_id]['selectors'] = $profile->getProjectIds();
       foreach (CRM_Twingle_Profile::allowedAttributes() as $attribute) {
         $profiles[$profile_name][$attribute] = $profile->getAttribute($attribute);
       }

--- a/CRM/Twingle/Page/Profiles.php
+++ b/CRM/Twingle/Page/Profiles.php
@@ -26,7 +26,7 @@ class CRM_Twingle_Page_Profiles extends CRM_Core_Page {
       $profiles[$profile_id]['is_default'] = $profile->is_default();
       $profiles[$profile_id]['selectors'] = $profile->getProjectIds();
       foreach (CRM_Twingle_Profile::allowedAttributes() as $attribute) {
-        $profiles[$profile_name][$attribute] = $profile->getAttribute($attribute);
+        $profiles[$profile_id][$attribute] = $profile->getAttribute($attribute);
       }
     }
     $this->assign('profiles', $profiles);

--- a/css/twingle.css
+++ b/css/twingle.css
@@ -1,0 +1,3 @@
+.twingle-profile-list {
+  border-bottom: 1px solid #cfcec3;
+}

--- a/templates/CRM/Twingle/Page/Profiles.tpl
+++ b/templates/CRM/Twingle/Page/Profiles.tpl
@@ -34,7 +34,7 @@
       <tbody>
       {foreach from=$profiles item=profile}
         {assign var="profile_name" value=$profile.name}
-        <tr style="border-bottom: 1px solid #cfcec3;">
+        <tr class="twingle-profile-list">
           <td>{$profile.name}</td>
           <td>
               {if not $profile.is_default}

--- a/templates/CRM/Twingle/Page/Profiles.tpl
+++ b/templates/CRM/Twingle/Page/Profiles.tpl
@@ -25,7 +25,7 @@
       <thead>
       <tr>
         <th>{ts domain="de.systopia.twingle"}Profile name{/ts}</th>
-        <th>{ts domain="de.systopia.twingle"}Properties{/ts}</th>
+        <th>{ts domain="de.systopia.twingle"}Selectors{/ts}</th>
         <th>{ts domain="de.systopia.twingle"}Used{/ts}</th>
         <th>{ts domain="de.systopia.twingle"}Last Used{/ts}</th>
         <th>{ts domain="de.systopia.twingle"}Operations{/ts}</th>
@@ -34,10 +34,16 @@
       <tbody>
       {foreach from=$profiles item=profile}
         {assign var="profile_name" value=$profile.name}
-        <tr>
+        <tr style="border-bottom: 1px solid #cfcec3;">
           <td>{$profile.name}</td>
           <td>
-            <div><strong>{ts domain="de.systopia.twingle"}Selector{/ts}:</strong> {$profile.selector}</div>
+              {if not $profile.is_default}
+                <ul>
+                    {foreach from=$profile.selectors item=selector}
+                      <li><strong></strong> {$selector}</li>
+                    {/foreach}
+                </ul>
+              {/if}
           </td>
           <td>{ts domain="de.systopia.twingle"}{$profile_stats.$profile_name.access_counter_txt}{/ts}</td>
           <td>{ts domain="de.systopia.twingle"}{$profile_stats.$profile_name.last_access_txt}{/ts}</td>


### PR DESCRIPTION
If a profile has a lot of Twingle profile IDs (like `tw6385beb0d1f55`), the profile list gets a bit messy. Therefore, I've changed the profile list view to display profile IDs as unordered list.

This PR depends on PR #75 because it uses the `Profile->is_default()` method.