### PR TITLE
Define permissions with label and description

### DIFF
--- a/twingle.php
+++ b/twingle.php
@@ -81,7 +81,10 @@ function twingle_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_permission
  */
 function twingle_civicrm_permission(&$permissions) {
-  $permissions['access Twingle API'] = 'Twingle API: Access Twingle API';
+  $permissions['access Twingle API'] = [
+    'label' => E::ts('Twingle API: Access Twingle API'),
+    'description' => E::ts('Allows access to the Twingle API actions.'),
+  ];
 }
 
 /**


### PR DESCRIPTION
Fixes `User deprecated function: Permission 'access Twingle API' should be declared with 'label' and 'description' keys.` deprecation warnings since CiviCRM `5.71.0`.

*systopia-reference: 24378*