### PR TITLE
Membership for organisations

### DIFF
--- a/api/v3/TwingleDonation/Submit.php
+++ b/api/v3/TwingleDonation/Submit.php
@@ -817,7 +817,7 @@ function civicrm_api3_twingle_donation_Submit($params) {
     // CREATE the membership if required
     if (isset($membership_type_id)) {
       $membership_data = [
-        'contact_id'         => $contact_id,
+        'contact_id'         => $organisation_id ?? $contact_id,
         'membership_type_id' => $membership_type_id,
       ];
       // set campaign, subject to configuration

--- a/api/v3/TwingleDonation/Submit.php
+++ b/api/v3/TwingleDonation/Submit.php
@@ -589,7 +589,8 @@ function civicrm_api3_twingle_donation_Submit($params) {
     }
 
     // If requested, add contact to donation_receipt groups defined in the
-    // profile.
+    // profile. If an organisation is provided, add it to the groups instead.
+    // (see issue #83)
     if (
       isset($params['donation_receipt'])
       && is_array($groups = $profile->getAttribute('donation_receipt_groups'))
@@ -597,7 +598,7 @@ function civicrm_api3_twingle_donation_Submit($params) {
       foreach ($groups as $group_id) {
         civicrm_api3('GroupContact', 'create', [
           'group_id' => $group_id,
-          'contact_id' => $contact_id,
+          'contact_id' => $organisation_id ?? $contact_id,
         ]);
 
         $result_values['donation_receipt'][] = $group_id;


### PR DESCRIPTION
When the `user_company` field is submitted, an organisation and an individual are currently created and linked. The downstream logic will then only refer to the individual and ignore the organisation. Instead, I would like to relate everything related to the contribution-contact relationship to the organisation rather than the individual.

This PR:
- creates a `donation_receipt` group membership for the organisation if one is provided.
- creates a membership for the organisation if one is provided.

I would argue that in this case we should refrain from making the change configurable, as the current behaviour is illogical (certainly in the case of the donation_receipt group).