### PR TITLE
Repair help links in settings form

### DIFF
--- a/templates/CRM/Twingle/Form/Settings.tpl
+++ b/templates/CRM/Twingle/Form/Settings.tpl
@@ -18,47 +18,41 @@
 
   <table class="form-layout-compressed">
     <tr class="crm-twingle-form-block-use-sepa">
-      <td class="label">{$form.twingle_use_sepa.label} &nbsp;<a onclick='CRM.help("{$form.twingle_use_sepa.label}", {literal}{"id":"id-{/literal}{$form.twingle_use_sepa.name}{literal}","file":"CRM\/Twingle\/Form\/Settings"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.twingle"}Help{/ts}" class="helpicon"></a></td>
+      <td class="label">
+        {$form.twingle_use_sepa.label}
+        {help id="id-twingle_use_sepa" title=$form.twingle_use_sepa.label}
+      </td>
       <td>
         {$form.twingle_use_sepa.html}
-        <br />
-        <span class="description">
-          {$formElements.twingle_use_sepa.description}
-        </span>
       </td>
     </tr>
 
     <tr class="crm-twingle-form-block-use-sepa-reference">
-      <td class="label">{$form.twingle_dont_use_reference.label} &nbsp; <a onclick='CRM.help("{$form.twingle_dont_use_reference.label}", {literal}{"id":"id-{/literal}{$form.twingle_dont_use_reference.name}{literal}","file":"CRM\/Twingle\/Form\/Settings"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.twingle"}Help{/ts}" class="helpicon"></a></td>
+      <td class="label">
+        {$form.twingle_dont_use_reference.label}
+        {help id="id-twingle_dont_use_reference" title=$form.twingle_dont_use_reference.label}
+      </td>
       <td>
         {$form.twingle_dont_use_reference.html}
-        <br />
-        <span class="description">
-          {$formElements.twingle_dont_use_reference.description}
-        </span>
       </td>
     </tr>
 
 
     <tr class="crm-twingle-form-block-prefix">
-      <td class="label">{$form.twingle_prefix.label} &nbsp;<a onclick='CRM.help("{$form.twingle_prefix.label}", {literal}{"id":"id-{/literal}{$form.twingle_prefix.name}{literal}","file":"CRM\/Twingle\/Form\/Settings"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.twingle"}Help{/ts}" class="helpicon"></a></td>
+      <td class="label">{$form.twingle_prefix.label}
+        {help id="id-twingle_prefix" title=$form.twingle_prefix.label}
+      </td>
       <td>
         {$form.twingle_prefix.html}
-        <br />
-        <span class="description">
-          {$formElements.twingle_prefix.description}
-        </span>
       </td>
     </tr>
 
     <tr class="crm-twingle-form-block-recurring-protection">
-      <td class="label">{$form.twingle_protect_recurring.label} &nbsp;<a onclick='CRM.help("{$form.twingle_protect_recurring.label}", {literal}{"id":"id-{/literal}{$form.twingle_protect_recurring.name}{literal}","file":"CRM\/Twingle\/Form\/Settings"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.twingle"}Help{/ts}" class="helpicon"></a></td>
+      <td class="label">{$form.twingle_protect_recurring.label}
+        {help id="id-twingle_protect_recurring" title=$form.twingle_protect_recurring.label}
+      </td>
       <td>
         {$form.twingle_protect_recurring.html}
-        <br />
-        <span class="description">
-          {$formElements.protect_recurring.description}
-        </span>
       </td>
     </tr>
 
@@ -66,10 +60,6 @@
       <td class="label">{$form.twingle_protect_recurring_activity_type.label}</td>
       <td>
         {$form.twingle_protect_recurring_activity_type.html}
-        <br />
-        <span class="description">
-          {$formElements.twingle_protect_recurring_activity_type.description}
-        </span>
       </td>
     </tr>
 
@@ -77,10 +67,6 @@
       <td class="label">{$form.twingle_protect_recurring_activity_subject.label}</td>
       <td>
         {$form.twingle_protect_recurring_activity_subject.html}
-        <br />
-        <span class="description">
-          {$formElements.twingle_protect_recurring_activity_subject.description}
-        </span>
       </td>
     </tr>
 
@@ -88,10 +74,6 @@
       <td class="label">{$form.twingle_protect_recurring_activity_status.label}</td>
       <td>
         {$form.twingle_protect_recurring_activity_status.html}
-        <br />
-        <span class="description">
-          {$formElements.twingle_protect_recurring_activity_status.description}
-        </span>
       </td>
     </tr>
 
@@ -99,15 +81,10 @@
       <td class="label">{$form.twingle_protect_recurring_activity_assignee.label}</td>
       <td>
         {$form.twingle_protect_recurring_activity_assignee.html}
-        <br />
-        <span class="description">
-          {$formElements.twingle_protect_recurring_activity_assignee.description}
-        </span>
       </td>
     </tr>
 
   </table>
-
 
   <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="bottom"}
@@ -116,22 +93,23 @@
 </div>
 
 {literal}
-<script>
-  /**
-   * Will show/hide the twingle_protect_recurring_activity_* fields based on
-   *  whether activity creation is selected
-   */
-  function twingle_protect_recurring_change() {
-    if (cj("#twingle_protect_recurring").val() == '2') {
-      cj("tr.crm-twingle-form-block-recurring-protection-activity").show();
-    } else {
-      cj("tr.crm-twingle-form-block-recurring-protection-activity").hide();
+  <script>
+    /**
+     * Will show/hide the twingle_protect_recurring_activity_* fields based on
+     *  whether activity creation is selected
+     */
+    function twingle_protect_recurring_change() {
+      if (cj('#twingle_protect_recurring').val() == '2') {
+        cj('tr.crm-twingle-form-block-recurring-protection-activity').show();
+      }
+      else {
+        cj('tr.crm-twingle-form-block-recurring-protection-activity').hide();
+      }
     }
-  }
 
-  cj(document).ready(function () {
-    cj("#twingle_protect_recurring").change(twingle_protect_recurring_change);
-    twingle_protect_recurring_change();
-  });
-</script>
+    cj(document).ready(function () {
+      cj('#twingle_protect_recurring').change(twingle_protect_recurring_change);
+      twingle_protect_recurring_change();
+    });
+  </script>
 {/literal}


### PR DESCRIPTION
This makes use of the (not so) new `{help}` Smarty tag for help bubbles in QuickForms, as they weren't working with the "old" notation.

There were also some *description* elements that weren't used, which got cleaned up.