### PR TITLE
Fix DAO/BAO namespaces and definitions

### DIFF
--- a/CRM/Twingle/BAO/TwingleProduct.php
+++ b/CRM/Twingle/BAO/TwingleProduct.php
@@ -1,16 +1,10 @@
 <?php
 
-namespace Civi\Twingle\Shop\BAO;
-
 use Civi\Api4\PriceField;
-use Civi\Twingle\Shop\DAO\TwingleProduct as TwingleProductDAO;
-use Civi\Twingle\Shop\DAO\TwingleShop as TwingleShopDAO;
+use Civi\Api4\PriceFieldValue;
 use Civi\Twingle\Shop\Exceptions\ProductException;
 use Civi\Twingle\Shop\Exceptions\ShopException;
-use CRM_Core_Exception;
-use CRM_Core_Transaction;
 use CRM_Twingle_ExtensionUtil as E;
-use CRM_Utils_Type;
 use function Civi\Twingle\Shop\Utils\convert_int_to_bool;
 use function Civi\Twingle\Shop\Utils\convert_str_to_date;
 use function Civi\Twingle\Shop\Utils\convert_str_to_int;
@@ -24,7 +18,7 @@ require_once E::path() . '/Civi/Twingle/Shop/Utils/TwingleShopUtils.php';
  * TwingleProduct BAO class.
  * This class is used to implement the logic for the TwingleProduct entity.
  */
-class TwingleProduct extends TwingleProductDAO {
+class CRM_Twingle_BAO_TwingleProduct extends CRM_Twingle_DAO_TwingleProduct {
 
   /**
    * Name of this product.
@@ -421,14 +415,14 @@ class TwingleProduct extends TwingleProductDAO {
    * @param int $external_id
    *   External id of the product (by Twingle)
    *
-   * @return TwingleProduct|null
+   * @return CRM_Twingle_BAO_TwingleProduct|null
     *   TwingleProduct object or NULL if not found
    *
    * @throws \Civi\Twingle\Shop\Exceptions\ProductException
    * @throws \Civi\Core\Exception\DBQueryException
    */
   public static function findByExternalId($external_id) {
-    $dao = TwingleShopDAO::executeQuery("SELECT * FROM civicrm_twingle_product WHERE external_id = %1",
+    $dao = CRM_Twingle_BAO_TwingleShop::executeQuery("SELECT * FROM civicrm_twingle_product WHERE external_id = %1",
       [1 => [$external_id, 'String']]);
     if ($dao->fetch()) {
       $product = new self();
@@ -456,7 +450,7 @@ class TwingleProduct extends TwingleProductDAO {
 
     // Try to lookup object in database
     try {
-      $dao = TwingleShopDAO::executeQuery("SELECT * FROM civicrm_twingle_product WHERE external_id = %1",
+      $dao = CRM_Twingle_BAO_TwingleShop::executeQuery("SELECT * FROM civicrm_twingle_product WHERE external_id = %1",
         [1 => [$this->external_id, 'String']]);
       if ($dao->fetch()) {
         $this->copyValues(array_merge($dao->toArray(), $this->getAttributes()));
@@ -514,7 +508,7 @@ class TwingleProduct extends TwingleProductDAO {
   /**
    * Delete TwingleProduct along with associated PriceField and PriceFieldValue.
    *
-   * @override \Civi\Twingle\Shop\DAO\TwingleProduct::delete
+   * @override \CRM_Twingle_DAO_TwingleProduct::delete
    * @throws \CRM_Core_Exception
    * @throws \Civi\Twingle\Shop\Exceptions\ProductException
    */
@@ -570,7 +564,7 @@ class TwingleProduct extends TwingleProductDAO {
   /**
    * Compare two products
    *
-   * @param TwingleProduct $product_to_compare_with
+   * @param CRM_Twingle_BAO_TwingleProduct $product_to_compare_with
    *   Product from database
    *
    * @return bool
@@ -592,7 +586,7 @@ class TwingleProduct extends TwingleProductDAO {
    */
   public function getFinancialTypeId(): ?int {
     if (!empty($this->price_field_id)) {
-      $price_set = \Civi\Api4\PriceField::get()
+      $price_set = PriceField::get()
         ->addSelect('financial_type_id')
         ->addWhere('id', '=', $this->price_field_id)
         ->execute()
@@ -610,7 +604,7 @@ class TwingleProduct extends TwingleProductDAO {
    */
   public function getPriceFieldValueId() {
     if (!empty($this->price_field_id)) {
-      $price_field_value = \Civi\Api4\PriceFieldValue::get()
+      $price_field_value = PriceFieldValue::get()
         ->addSelect('id')
         ->addWhere('price_field_id', '=', $this->price_field_id)
         ->execute()

--- a/CRM/Twingle/BAO/TwingleShop.php
+++ b/CRM/Twingle/BAO/TwingleShop.php
@@ -1,15 +1,10 @@
 <?php
 
-namespace Civi\Twingle\Shop\BAO;
-
 // phpcs:disable
 use CRM_Twingle_ExtensionUtil as E;
-use Civi\Twingle\Shop\DAO\TwingleShop as TwingleShopDAO;
-use Civi\Twingle\Shop\BAO\TwingleProduct as TwingleProductBAO;
 use Civi\Twingle\Shop\ApiCall;
 use Civi\Twingle\Shop\Exceptions\ShopException;
 use Civi\Twingle\Shop\Exceptions\ProductException;
-use Exception;
 use function Civi\Twingle\Shop\Utils\filter_attributes;
 use function Civi\Twingle\Shop\Utils\convert_str_to_int;
 use function Civi\Twingle\Shop\Utils\validate_data_types;
@@ -17,7 +12,7 @@ use function Civi\Twingle\Shop\Utils\validate_data_types;
 
 require_once E::path() . '/Civi/Twingle/Shop/Utils/TwingleShopUtils.php';
 
-class TwingleShop extends TwingleShopDAO {
+class CRM_Twingle_BAO_TwingleShop extends CRM_Twingle_DAO_TwingleShop {
 
   public const ALLOWED_ATTRIBUTES = [
     'id' => \CRM_Utils_Type::T_INT,
@@ -64,14 +59,14 @@ class TwingleShop extends TwingleShopDAO {
    * @param string $project_identifier
    *   Twingle project identifier
    *
-   * @return TwingleShop
+   * @return CRM_Twingle_BAO_TwingleShop
    *
    * @throws ShopException
    * @throws \Civi\Twingle\Shop\Exceptions\ApiCallError
    * @throws \CRM_Core_Exception
    */
   public static function findByProjectIdentifier(string $project_identifier) {
-    $shop = new TwingleShop();
+    $shop = new CRM_Twingle_BAO_TwingleShop();
     $shop->get('project_identifier', $project_identifier);
     if (!$shop->id) {
       $shop->fetchDataFromTwingle($project_identifier);
@@ -147,7 +142,7 @@ class TwingleShop extends TwingleShopDAO {
 
     // Try to lookup object in database
     try {
-      $dao = TwingleShopDAO::executeQuery("SELECT * FROM civicrm_twingle_shop WHERE project_identifier = %1",
+      $dao = self::executeQuery("SELECT * FROM civicrm_twingle_shop WHERE project_identifier = %1",
         [1 => [$this->project_identifier, 'String']]);
       if ($dao->fetch()) {
         $this->load($dao->toArray());
@@ -259,7 +254,7 @@ class TwingleShop extends TwingleShopDAO {
       }, []);
 
       foreach ($products_from_db as $product) {
-        /* @var TwingleProductBAO $product */
+        /* @var CRM_Twingle_BAO_TwingleProduct $product */
 
         // Find orphaned products which are in the database but not in Twingle
         $found = array_key_exists($product->external_id, $products_from_twingle);
@@ -286,8 +281,8 @@ class TwingleShop extends TwingleShopDAO {
     foreach ($products_from_twingle as $product_from_twingle) {
       $found = array_key_exists($product_from_twingle['id'], $products);
       if (!$found) {
-        $product = new TwingleProduct();
-        $product->load(TwingleProduct::renameTwingleAttrs($product_from_twingle));
+        $product = new CRM_Twingle_BAO_TwingleProduct();
+        $product->load(CRM_Twingle_BAO_TwingleProduct::renameTwingleAttrs($product_from_twingle));
         $product->twingle_shop_id = $this->id;
         $this->products[] = $product;
       }
@@ -305,13 +300,13 @@ class TwingleShop extends TwingleShopDAO {
   public function getProducts() {
     $products = [];
 
-    $result = TwingleProductBAO::executeQuery(
+    $result = CRM_Twingle_BAO_TwingleProduct::executeQuery(
       "SELECT * FROM civicrm_twingle_product WHERE twingle_shop_id = %1",
       [1 => [$this->id, 'Integer']]
     );
 
     while ($result->fetch()) {
-      $product = new TwingleProductBAO();
+      $product = new CRM_Twingle_BAO_TwingleProduct();
       $product->load($result->toArray());
       $products[] = $product;
     }

--- a/CRM/Twingle/DAO/TwingleProduct.php
+++ b/CRM/Twingle/DAO/TwingleProduct.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Civi\Twingle\Shop\DAO;
-
 /**
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
@@ -15,7 +13,7 @@ use CRM_Twingle_ExtensionUtil as E;
 /**
  * Database access object for the TwingleProduct entity.
  */
-class TwingleProduct extends \CRM_Core_DAO {
+class CRM_Twingle_DAO_TwingleProduct extends CRM_Core_DAO {
   const EXT = E::LONG_NAME;
   const TABLE_ADDED = '';
 
@@ -144,7 +142,7 @@ class TwingleProduct extends \CRM_Core_DAO {
           'where' => 'civicrm_twingle_product.id',
           'table_name' => 'civicrm_twingle_product',
           'entity' => 'TwingleProduct',
-          'bao' => 'Civi\Twingle\Shop\DAO\TwingleProduct',
+          'bao' => 'CRM_Twingle_DAO_TwingleProduct',
           'localizable' => 0,
           'html' => [
             'type' => 'Number',
@@ -167,7 +165,7 @@ class TwingleProduct extends \CRM_Core_DAO {
           'where' => 'civicrm_twingle_product.external_id',
           'table_name' => 'civicrm_twingle_product',
           'entity' => 'TwingleProduct',
-          'bao' => 'Civi\Twingle\Shop\DAO\TwingleProduct',
+          'bao' => 'CRM_Twingle_DAO_TwingleProduct',
           'localizable' => 0,
           'html' => [
             'type' => 'Number',
@@ -189,7 +187,7 @@ class TwingleProduct extends \CRM_Core_DAO {
           'where' => 'civicrm_twingle_product.price_field_id',
           'table_name' => 'civicrm_twingle_product',
           'entity' => 'TwingleProduct',
-          'bao' => 'Civi\Twingle\Shop\DAO\TwingleProduct',
+          'bao' => 'CRM_Twingle_DAO_TwingleProduct',
           'localizable' => 0,
           'FKClassName' => 'CRM_Contact_DAO_Contact',
           'add' => NULL,
@@ -208,9 +206,9 @@ class TwingleProduct extends \CRM_Core_DAO {
           'where' => 'civicrm_twingle_product.twingle_shop_id',
           'table_name' => 'civicrm_twingle_product',
           'entity' => 'TwingleProduct',
-          'bao' => 'Civi\Twingle\Shop\DAO\TwingleProduct',
+          'bao' => 'CRM_Twingle_DAO_TwingleProduct',
           'localizable' => 0,
-          'FKClassName' => 'Civi\Twingle\Shop\DAO\TwingleShop',
+          'FKClassName' => 'CRM_Twingle_DAO_TwingleShop',
           'add' => NULL,
         ],
         'created_at' => [
@@ -228,7 +226,7 @@ class TwingleProduct extends \CRM_Core_DAO {
           'where' => 'civicrm_twingle_product.created_at',
           'table_name' => 'civicrm_twingle_product',
           'entity' => 'TwingleProduct',
-          'bao' => 'Civi\Twingle\Shop\DAO\TwingleProduct',
+          'bao' => 'CRM_Twingle_DAO_TwingleProduct',
           'localizable' => 0,
           'add' => NULL,
         ],
@@ -247,7 +245,7 @@ class TwingleProduct extends \CRM_Core_DAO {
           'where' => 'civicrm_twingle_product.updated_at',
           'table_name' => 'civicrm_twingle_product',
           'entity' => 'TwingleProduct',
-          'bao' => 'Civi\Twingle\Shop\DAO\TwingleProduct',
+          'bao' => 'CRM_Twingle_DAO_TwingleProduct',
           'localizable' => 0,
           'add' => NULL,
         ],

--- a/CRM/Twingle/DAO/TwingleShop.php
+++ b/CRM/Twingle/DAO/TwingleShop.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Civi\Twingle\Shop\DAO;
-
 /**
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
@@ -15,7 +13,7 @@ use CRM_Twingle_ExtensionUtil as E;
 /**
  * Database access object for the TwingleShop entity.
  */
-class TwingleShop extends \CRM_Core_DAO {
+class CRM_Twingle_DAO_TwingleShop extends CRM_Core_DAO {
   const EXT = E::LONG_NAME;
   const TABLE_ADDED = '';
 
@@ -134,7 +132,7 @@ class TwingleShop extends \CRM_Core_DAO {
           'where' => 'civicrm_twingle_shop.id',
           'table_name' => 'civicrm_twingle_shop',
           'entity' => 'TwingleShop',
-          'bao' => 'Civi\Twingle\Shop\DAO\TwingleShop',
+          'bao' => 'CRM_Twingle_DAO_TwingleShop',
           'localizable' => 0,
           'html' => [
             'type' => 'Number',
@@ -159,7 +157,7 @@ class TwingleShop extends \CRM_Core_DAO {
           'where' => 'civicrm_twingle_shop.project_identifier',
           'table_name' => 'civicrm_twingle_shop',
           'entity' => 'TwingleShop',
-          'bao' => 'Civi\Twingle\Shop\DAO\TwingleShop',
+          'bao' => 'CRM_Twingle_DAO_TwingleShop',
           'localizable' => 0,
           'html' => [
             'type' => 'Text',
@@ -181,7 +179,7 @@ class TwingleShop extends \CRM_Core_DAO {
           'where' => 'civicrm_twingle_shop.numerical_project_id',
           'table_name' => 'civicrm_twingle_shop',
           'entity' => 'TwingleShop',
-          'bao' => 'Civi\Twingle\Shop\DAO\TwingleShop',
+          'bao' => 'CRM_Twingle_DAO_TwingleShop',
           'localizable' => 0,
           'html' => [
             'type' => 'Number',
@@ -202,7 +200,7 @@ class TwingleShop extends \CRM_Core_DAO {
           'where' => 'civicrm_twingle_shop.price_set_id',
           'table_name' => 'civicrm_twingle_shop',
           'entity' => 'TwingleShop',
-          'bao' => 'Civi\Twingle\Shop\DAO\TwingleShop',
+          'bao' => 'CRM_Twingle_DAO_TwingleShop',
           'localizable' => 0,
           'FKClassName' => 'CRM_Price_DAO_PriceSet',
           'add' => NULL,

--- a/info.xml
+++ b/info.xml
@@ -20,7 +20,11 @@
   <compatibility>
     <ver>5.58</ver>
   </compatibility>
-  <comments/>
+  <comments></comments>
+  <classloader>
+    <psr4 prefix="Civi\" path="Civi"/>
+    <psr0 prefix="CRM_" path="."/>
+  </classloader>
   <requires>
     <ext>de.systopia.xcm</ext>
   </requires>
@@ -32,10 +36,7 @@
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>mgd-php@1.0.0</mixin>
     <mixin>smarty-v2@1.0.1</mixin>
+    <mixin>entity-types-php@1.0.0</mixin>
   </mixins>
-  <classloader>
-    <psr0 prefix="CRM_" path="."/>
-    <psr4 prefix="Civi\" path="Civi"/>
-  </classloader>
   <upgrader>CRM_Twingle_Upgrader</upgrader>
 </extension>

--- a/twingle.civix.php
+++ b/twingle.civix.php
@@ -198,25 +198,3 @@ function _twingle_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
     }
   }
 }
-
-/**
- * (Delegated) Implements hook_civicrm_entityTypes().
- *
- * Find any *.entityType.php files, merge their content, and return.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
- */
-function _twingle_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, [
-    'Civi\Twingle\Shop\DAO\TwingleProduct' => [
-      'name' => 'TwingleProduct',
-      'class' => 'Civi\Twingle\Shop\DAO\TwingleProduct',
-      'table' => 'civicrm_twingle_product',
-    ],
-    'Civi\Twingle\Shop\DAO\TwingleShop' => [
-      'name' => 'TwingleShop',
-      'class' => 'Civi\Twingle\Shop\DAO\TwingleShop',
-      'table' => 'civicrm_twingle_shop',
-    ],
-  ]);
-}

--- a/xml/schema/CRM/Twingle/TwingleProduct.entityType.php
+++ b/xml/schema/CRM/Twingle/TwingleProduct.entityType.php
@@ -4,7 +4,7 @@
 return [
   [
     'name' => 'TwingleProduct',
-    'class' => 'Civi\Twingle\Shop\DAO\TwingleProduct',
+    'class' => 'CRM_Twingle_DAO_TwingleProduct',
     'table' => 'civicrm_twingle_product',
   ],
 ];

--- a/xml/schema/CRM/Twingle/TwingleProduct.xml
+++ b/xml/schema/CRM/Twingle/TwingleProduct.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 
 <table>
-  <base>CRM/Twingle/Shop</base>
+  <base>CRM/Twingle</base>
   <class>TwingleProduct</class>
   <name>civicrm_twingle_product</name>
   <comment>This table contains the Twingle Product data.</comment>

--- a/xml/schema/CRM/Twingle/TwingleShop.entityType.php
+++ b/xml/schema/CRM/Twingle/TwingleShop.entityType.php
@@ -4,7 +4,7 @@
 return [
   [
     'name' => 'TwingleShop',
-    'class' => 'Civi\Twingle\Shop\DAO\TwingleShop',
+    'class' => 'CRM_Twingle_DAO_TwingleShop',
     'table' => 'civicrm_twingle_shop',
   ],
 ];

--- a/xml/schema/CRM/Twingle/TwingleShop.xml
+++ b/xml/schema/CRM/Twingle/TwingleShop.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 
 <table>
-  <base>CRM/Twingle/Shop</base>
+  <base>CRM/Twingle</base>
   <class>TwingleShop</class>
   <name>civicrm_twingle_shop</name>
   <comment>This table contains the Twingle Shop data. Each Twingle Shop is linked to a corresponding Price Set.</comment>


### PR DESCRIPTION
After merging #69 without an in-depth review, I noticed errors in the API explorer resulting from incorrect namespaces for the DAO/BAO classes. This PR fixes those. Clearing caches after applying those changes is needed.

@MarcMichalsky would you be able to give this a try?

Also, I think a follow-up for some more fixes would be reasonable. I noticed some global functions defined in `TwingleShopUtils.php` that should be static class methods or be replaced by language constructs. They're probably resulting from the extensive PHPStan fixes we did before merging all your PRs …