### PR TITLE
Add profile option for using booking date if provided

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        civicrm-image-tags: [ '5-drupal-php8.1', '5-drupal-php7.4', '5.56-drupal-php7.4' ]
+        civicrm-image-tags: [ '6-drupal', '6-drupal-php8.1', '5.58-drupal-php8.1' ]
     name: PHPUnit with Docker image michaelmcandrew/civicrm:${{ matrix.civicrm-image-tags }}
     env:
       CIVICRM_IMAGE_TAG: ${{ matrix.civicrm-image-tags }}

--- a/CRM/Twingle/Form/Profile.php
+++ b/CRM/Twingle/Form/Profile.php
@@ -679,9 +679,12 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
         }
         $this->profile->setName($values['name']);
         foreach ($this->profile->getData() as $element_name => $value) {
-          if ($element_name == 'newsletter_double_opt_in') {
+          // Store unset checkboxes.
+          if (in_array($element_name, $this->profile->check_box_fields, TRUE)) {
+            // TODO: Use bool.
             $values[$element_name] = (int) isset($values[$element_name]);
           }
+
           if (isset($values[$element_name])) {
             $this->profile->setAttribute($element_name, $values[$element_name]);
           }

--- a/CRM/Twingle/Form/Profile.php
+++ b/CRM/Twingle/Form/Profile.php
@@ -315,6 +315,12 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
     );
 
     $this->add(
+      'checkbox',
+      'use_booking_date',
+      E::ts('Use booking date if available')
+    );
+
+    $this->add(
       'select',
       'gender_male',
       E::ts('Gender option for submitted value "male"'),
@@ -393,7 +399,7 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
       'checkbox',
       'newsletter_double_opt_in',
       E::ts('Use Double-Opt-In for newsletter')
-      );
+    );
 
     $this->add(
       'select',
@@ -528,39 +534,37 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
       ['class' => 'crm-select2 huge', 'multiple' => 'multiple']
     );
 
-    if (Civi::settings()->get('twingle_use_shop')) {
+    /** @phpstan-var bool $useShop */
+    $useShop = Civi::settings()->get('twingle_use_shop');
+    if ($useShop) {
       $this->add(
-        'checkbox', // field type
-        'enable_shop_integration', // field name
-        E::ts('Enable Shop Integration'), // field label
-        FALSE,
-        []
+        'checkbox',
+        'enable_shop_integration',
+        E::ts('Enable Shop Integration')
       );
 
       $this->add(
-        'select', // field type
-        'shop_financial_type', // field name
-        E::ts('Default Financial Type'), // field label
-        static::getFinancialTypes(), // list of options
+        'select',
+        'shop_financial_type',
+        E::ts('Default Financial Type'),
+        static::getFinancialTypes(),
         TRUE,
         ['class' => 'crm-select2 huge']
       );
 
       $this->add(
-        'select', // field type
-        'shop_donation_financial_type', // field name
-        E::ts('Financial Type for top up donations'), // field label
-        static::getFinancialTypes(), // list of options
+        'select',
+        'shop_donation_financial_type',
+        E::ts('Financial Type for top up donations'),
+        static::getFinancialTypes(),
         TRUE,
         ['class' => 'crm-select2 huge']
       );
 
       $this->add(
-        'checkbox', // field type
-        'shop_map_products', // field name
-        E::ts('Map Products as Price Fields'), // field label
-        FALSE, // is not required
-        []
+        'checkbox',
+        'shop_map_products',
+        E::ts('Map Products as Price Fields')
       );
     }
 

--- a/CRM/Twingle/Profile.php
+++ b/CRM/Twingle/Profile.php
@@ -510,6 +510,10 @@ class CRM_Twingle_Profile {
           'label' => E::ts('Financial type (recurring)'),
           'required' => TRUE,
         ],
+        'use_booking_date' => [
+          'label' => E::ts('Use booking date if available'),
+          'required' => FALSE,
+        ],
         'sepa_creditor_id' => [
           'label' => E::ts('CiviSEPA creditor'),
           'required' => CRM_Twingle_Submission::civiSepaEnabled(),
@@ -633,6 +637,7 @@ class CRM_Twingle_Profile {
       'financial_type_id' => 1,
       // "Donation"
       'financial_type_id_recur' => 1,
+      'use_booking_date' => TRUE,
       // "EFT"
       'pi_banktransfer' => 5,
       'pi_debit_manual' => NULL,

--- a/CRM/Twingle/Profile.php
+++ b/CRM/Twingle/Profile.php
@@ -49,6 +49,7 @@ class CRM_Twingle_Profile {
    */
   public $check_box_fields = [
     'newsletter_double_opt_in',
+    'use_booking_date',
     'enable_shop_integration',
     'shop_map_products',
   ];

--- a/CRM/Twingle/Submission.php
+++ b/CRM/Twingle/Submission.php
@@ -442,7 +442,9 @@ class CRM_Twingle_Submission {
     CRM_Twingle_Profile $profile
   ): void {
     // first: make sure it's not set from other workflows
-    unset($entity_data['campaign_id']);
+    if (isset($entity_data['campaign_id'])) {
+      unset($entity_data['campaign_id']);
+    }
 
     // then: check if campaign should be set it this context
     $enabled_contexts = $profile->getAttribute('campaign_targets');
@@ -452,7 +454,7 @@ class CRM_Twingle_Submission {
     }
     if (in_array($context, $enabled_contexts, TRUE)) {
       // use the submitted campaign if set
-      if (is_numeric($submission['campaign_id'])) {
+      if (is_numeric($submission['campaign_id'] ?? NULL)) {
         $entity_data['campaign_id'] = $submission['campaign_id'];
       }
       // otherwise use the profile's

--- a/api/v3/TwingleDonation/Submit.php
+++ b/api/v3/TwingleDonation/Submit.php
@@ -326,7 +326,7 @@ function civicrm_api3_twingle_donation_Submit($params) {
     // Extract custom field values using the profile's mapping of Twingle fields
     // to CiviCRM custom fields.
     $custom_fields = [];
-    if (is_array($params['custom_fields'])) {
+    if (is_array($params['custom_fields'] ?? NULL)) {
       $custom_field_mapping = $profile->getCustomFieldMapping();
 
       // Make all params available for custom field mapping
@@ -456,7 +456,7 @@ function civicrm_api3_twingle_donation_Submit($params) {
       }
 
       // Organisation lookup.
-      if (is_string($params['organization_name']) && '' !== $params['organization_name']) {
+      if (is_string($params['organization_name'] ?? NULL) && '' !== $params['organization_name']) {
         $organisation_data = [
           'organization_name' => $params['organization_name'],
         ];

--- a/api/v3/TwingleDonation/Submit.php
+++ b/api/v3/TwingleDonation/Submit.php
@@ -52,6 +52,13 @@ function _civicrm_api3_twingle_donation_Submit_spec(&$params) {
     'api.required' => 1,
     'description'  => E::ts('The date when the donation was issued, format: YmdHis.'),
   ];
+  $params['booked_at'] = [
+    'name'         => 'booked_at',
+    'title'        => E::ts('Booked at'),
+    'type'         => CRM_Utils_Type::T_STRING,
+    'api.required' => 0,
+    'description'  => E::ts('The date when the donation was booked, format: YmdHis.'),
+  ];
   $params['purpose'] = [
     'name'         => 'purpose',
     'title'        => E::ts('Purpose'),
@@ -796,8 +803,9 @@ function civicrm_api3_twingle_donation_Submit($params) {
         // set campaign, subject to configuration
         CRM_Twingle_Submission::setCampaign($contribution_data, 'recurring', $params, $profile);
 
+        /** @phpstan-var array<string, mixed> $contribution_recur */
         $contribution_recur = civicrm_api3('ContributionRecur', 'create', $contribution_recur_data);
-        if ($contribution_recur['is_error']) {
+        if ((bool) $contribution_recur['is_error']) {
           throw new CRM_Core_Exception(
             E::ts('Could not create recurring contribution.'),
             'api_error'
@@ -807,18 +815,25 @@ function civicrm_api3_twingle_donation_Submit($params) {
         $contribution_data['financial_type_id'] = $contribution_recur_data['financial_type_id'];
       }
 
-      // Create contribution.
+      /** @phpstan-var bool $useBookingDate */
+      // TODO: Add upgrade task for setting this option to FALSE for existing profiles.
+      $useBookingDate = $profile->getAttribute('use_booking_date') ?? FALSE;
+      $bookingDate = isset($params['booked_at'])
+        ? date_create_from_format('YmdHis', $params['booked_at'])
+        : FALSE;
+
       $contribution_data += [
         'contribution_status_id' => $profile->getAttribute(
           "pi_{$params['payment_method']}_status",
           CRM_Twingle_Submission::CONTRIBUTION_STATUS_COMPLETED
         ),
-        'receive_date' => $params['confirmed_at'],
+        'receive_date' => $useBookingDate && FALSE !== $bookingDate ? $params['booked_at'] : $params['confirmed_at'],
       ];
 
       // Assign to recurring contribution.
       if (!empty($params['parent_trx_id'])) {
         try {
+          /** @phpstan-var array<string, mixed> $parent_contribution */
           $parent_contribution = civicrm_api3('ContributionRecur', 'getsingle', [
             'trxn_id' => $profile->getTransactionID($params['parent_trx_id']),
           ]);

--- a/api/v3/TwingleDonation/Submit.php
+++ b/api/v3/TwingleDonation/Submit.php
@@ -816,7 +816,6 @@ function civicrm_api3_twingle_donation_Submit($params) {
       }
 
       /** @phpstan-var bool $useBookingDate */
-      // TODO: Add upgrade task for setting this option to FALSE for existing profiles.
       $useBookingDate = $profile->getAttribute('use_booking_date') ?? FALSE;
       $bookingDate = isset($params['booked_at'])
         ? date_create_from_format('YmdHis', $params['booked_at'])

--- a/ci/composer.json
+++ b/ci/composer.json
@@ -9,7 +9,8 @@
         }
     },
     "require": {
-        "civicrm/civicrm-core": "^5"
+        "civicrm/civicrm-core": "^5",
+        "civicrm/civicrm-packages": "^5"
     },
     "scripts": {
         "post-install-or-update": [

--- a/phpstan.ci.neon
+++ b/phpstan.ci.neon
@@ -3,7 +3,11 @@ includes:
 
 parameters:
 	scanDirectories:
+		- ci/vendor/civicrm/civicrm-core/api/
 		- ci/vendor/civicrm/civicrm-core/CRM/
+		- ci/vendor/civicrm/civicrm-core/Civi/
+		- ci/vendor/civicrm/civicrm-core/ext/civi_contribute/
+		- ci/vendor/civicrm/civicrm-packages/
 	bootstrapFiles:
 		- ci/vendor/autoload.php
 	# Because we test with different versions in CI we have unmatched errors

--- a/phpstan.neon.template
+++ b/phpstan.neon.template
@@ -6,9 +6,10 @@ includes:
 
 parameters:
 	scanDirectories:
+		- {VENDOR_DIR}/civicrm/civicrm-core/api/
 		- {VENDOR_DIR}/civicrm/civicrm-core/Civi/
 		- {VENDOR_DIR}/civicrm/civicrm-core/CRM/
-		- {VENDOR_DIR}/civicrm/civicrm-core/api/
+		- {VENDOR_DIR}/civicrm/civicrm-core/ext/civi_contribute/
 		- {VENDOR_DIR}/civicrm/civicrm-packages/
 	bootstrapFiles:
 		- {VENDOR_DIR}/autoload.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,32 +1,24 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
-         colors="true"
-         failOnRisky="true"
-         failOnWarning="true"
-         forceCoversAnnotation="true"
-         bootstrap="tests/phpunit/bootstrap.php">
-
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" colors="true" failOnRisky="true" failOnWarning="true" forceCoversAnnotation="true" bootstrap="tests/phpunit/bootstrap.php">
+  <coverage>
+    <include>
+      <directory suffix=".php">api</directory>
+      <directory suffix=".php">CRM</directory>
+      <directory suffix=".php">Civi</directory>
+    </include>
+    <exclude>
+      <directory>CRM/*/DAO</directory>
+    </exclude>
+  </coverage>
   <php>
-    <ini name="error_reporting" value="-1" />
+    <ini name="error_reporting" value="-1"/>
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0&amp;baselineFile=./tests/ignored-deprecations.json"/>
   </php>
-
   <testsuites>
     <testsuite name="Extension Test Suite">
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">api</directory>
-      <directory suffix=".php">CRM</directory>
-      <directory suffix=".php">Civi</directory>
-      <exclude>
-        <directory>CRM/*/DAO</directory>
-      </exclude>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/templates/CRM/Twingle/Form/Profile.tpl
+++ b/templates/CRM/Twingle/Form/Profile.tpl
@@ -180,6 +180,11 @@
           <td class="content">{$form.financial_type_id_recur.html}</td>
         </tr>
 
+        <tr class="crm-section">
+          <td class="label">{$form.use_booking_date.label}</td>
+          <td class="content">{$form.use_booking_date.html}</td>
+        </tr>
+
         {if isset($form.sepa_creditor_id)}
           <tr class="crm-section">
             <td class="label">{$form.sepa_creditor_id.label}</td>

--- a/tests/docker-prepare.sh
+++ b/tests/docker-prepare.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eu -o pipefail
 
+XCM_VERSION=1.13.0
+
 EXT_DIR=$(dirname "$(dirname "$(realpath "$0")")")
 EXT_NAME=$(basename "$EXT_DIR")
 
@@ -36,6 +38,8 @@ else
   # For headless tests these files need to exist.
   touch /var/www/html/sites/all/modules/civicrm/sql/test_data.mysql
   touch /var/www/html/sites/all/modules/civicrm/sql/test_data_second_domain.mysql
+
+  cv ext:download "de.systopia.xcm@https://github.com/systopia/de.systopia.xcm/releases/download/$XCM_VERSION/de.systopia.xcm-$XCM_VERSION.zip"
 
   cv ext:enable "$EXT_NAME"
 fi

--- a/tests/phpunit/api/v3/TwingleDonation/SubmitTest.php
+++ b/tests/phpunit/api/v3/TwingleDonation/SubmitTest.php
@@ -35,13 +35,13 @@ class api_v3_TwingleDonation_SubmitTest extends \PHPUnit\Framework\TestCase impl
 
   use \Civi\Test\Api3TestTrait;
 
-  private const string PROJECT_ID = 'tw583f49b20c7bf';
+  private const PROJECT_ID = 'tw583f49b20c7bf';
 
-  private const string BOOKING_DATE = '20250424080844';
+  private const BOOKING_DATE = '20250424080844';
 
-  private const string CONFIRMATION_DATE = '20250424100831';
+  private const CONFIRMATION_DATE = '20250424100831';
 
-  private const array SUBMISSION = [
+  private const SUBMISSION = [
     'project_id' => self::PROJECT_ID,
     'trx_id' => 'GL947LC',
     'parent_trx_id' => NULL,

--- a/tests/phpunit/api/v3/TwingleDonation/SubmitTest.php
+++ b/tests/phpunit/api/v3/TwingleDonation/SubmitTest.php
@@ -1,0 +1,110 @@
+<?php
+/*------------------------------------------------------------+
+| SYSTOPIA Twingle Integration                                |
+| Copyright (C) 2025 SYSTOPIA                                 |
+| Author: J. Schuppe (schuppe@systopia.de)                    |
++-------------------------------------------------------------+
+| This program is released as free software under the         |
+| Affero GPL license. You can redistribute it and/or          |
+| modify it under the terms of this license which you         |
+| can read by viewing the included agpl.txt or online         |
+| at www.gnu.org/licenses/agpl.html. Removal of this          |
+| copyright header is strictly prohibited without             |
+| written permission from the original author(s).             |
++-------------------------------------------------------------*/
+
+declare(strict_types = 1);
+
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+use Civi\Api4\Contribution;
+use CRM_Twingle_ExtensionUtil as E;
+
+/**
+ * TwingleDonation.Submit API Test Case
+ * This is a generic test class implemented with PHPUnit.
+ *
+ * @group headless
+ * @covers ::\civicrm_api3_twingle_donation_Submit()
+ */
+// phpcs:disable Generic.Files.LineLength.TooLong
+class api_v3_TwingleDonation_SubmitTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+// phpcs: enable
+
+  use \Civi\Test\Api3TestTrait;
+
+  private const string PROJECT_ID = 'tw583f49b20c7bf';
+
+  private const string BOOKING_DATE = '20250424080844';
+
+  private const string CONFIRMATION_DATE = '20250424100831';
+
+  private const array SUBMISSION = [
+    'project_id' => self::PROJECT_ID,
+    'trx_id' => 'GL947LC',
+    'parent_trx_id' => NULL,
+    'confirmed_at' => self::CONFIRMATION_DATE,
+    'booked_at' => self::BOOKING_DATE,
+    'purpose' => 'Schulprojekte',
+    'amount' => 1000,
+    'currency' => 'EUR',
+    'remarks' => NULL,
+    'user_email' => 'test@example.org',
+    'user_country' => 'DE',
+    'user_language' => 'de',
+    'payment_method' => 'creditcard',
+    'donation_rhythm' => 'one_time',
+    'is_anonymous' => 0,
+    'newsletter' => 0,
+    'postinfo' => 0,
+    'donation_receipt' => 0,
+    'user_title' => NULL,
+    'user_firstname' => NULL,
+    'user_lastname' => NULL,
+    'user_gender' => NULL,
+    'user_street' => NULL,
+    'user_postal_code' => NULL,
+    'user_city' => NULL,
+    'user_telephone' => NULL,
+    'user_company' => NULL,
+    'user_extrafield' => NULL,
+  ];
+
+  /**
+   * {@inheritDoc}
+   */
+  public function setUpHeadless(): CiviEnvBuilder {
+    return \Civi\Test::headless()
+      ->install(['de.systopia.xcm'])
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  /**
+   * Test contribution date selection.
+   */
+  public function testContributionDate(): void {
+    /** @var array{values: array{contribution: array{id: int|string, receive_date: string}}} $result */
+    $result = civicrm_api3('TwingleDonation', 'submit', self::SUBMISSION);
+    // Assert that booking date has been used as contribution date when configured (profile default).
+    self::assertEquals(self::BOOKING_DATE, $result['values']['contribution']['receive_date']);
+
+    // TODO: Test date selection with a submission without a booking date.
+
+    // Delete contribution and set profile to not use booking date.
+    Contribution::delete(FALSE)
+      ->addWhere('id', '=', $result['values']['contribution']['id'])
+      ->execute();
+    $profile = \CRM_Twingle_Profile::getProfileForProject(self::PROJECT_ID);
+    $profile->setAttribute('use_booking_date', FALSE);
+    $profile->saveProfile();
+
+    /** @var array{values: array{contribution: array{id: int|string, receive_date: string}}} $result */
+    $result = civicrm_api3('TwingleDonation', 'submit', self::SUBMISSION);
+    // Assert that confirmation date has been used as contribution date when configured.
+    self::assertEquals(self::CONFIRMATION_DATE, $result['values']['contribution']['receive_date']);
+  }
+
+}

--- a/tests/phpunit/api/v3/TwingleDonation/SubmitTest.php
+++ b/tests/phpunit/api/v3/TwingleDonation/SubmitTest.php
@@ -17,7 +17,6 @@ declare(strict_types = 1);
 
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
 use Civi\Api4\Contribution;
 use CRM_Twingle_ExtensionUtil as E;
@@ -30,7 +29,7 @@ use CRM_Twingle_ExtensionUtil as E;
  * @covers ::\civicrm_api3_twingle_donation_Submit()
  */
 // phpcs:disable Generic.Files.LineLength.TooLong
-class api_v3_TwingleDonation_SubmitTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+class api_v3_TwingleDonation_SubmitTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
 // phpcs: enable
 
   use \Civi\Test\Api3TestTrait;

--- a/tests/phpunit/api/v3/TwingleProduct/CreateTest.php
+++ b/tests/phpunit/api/v3/TwingleProduct/CreateTest.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**
@@ -14,7 +13,7 @@ use Civi\Test\TransactionalInterface;
  * @group headless
  */
 // phpcs:disable Generic.Files.LineLength.TooLong
-class api_v3_TwingleProduct_CreateTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+class api_v3_TwingleProduct_CreateTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
 // phpcs: enable
 
   use \Civi\Test\Api3TestTrait;

--- a/tests/phpunit/api/v3/TwingleProduct/CreateTest.php
+++ b/tests/phpunit/api/v3/TwingleProduct/CreateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\HookInterface;
@@ -8,9 +10,13 @@ use Civi\Test\TransactionalInterface;
 /**
  * TwingleProduct.Create API Test Case
  * This is a generic test class implemented with PHPUnit.
+ *
  * @group headless
  */
+// phpcs:disable Generic.Files.LineLength.TooLong
 class api_v3_TwingleProduct_CreateTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+// phpcs: enable
+
   use \Civi\Test\Api3TestTrait;
 
   /**

--- a/tests/phpunit/api/v3/TwingleProduct/DeleteTest.php
+++ b/tests/phpunit/api/v3/TwingleProduct/DeleteTest.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**
@@ -14,7 +13,7 @@ use Civi\Test\TransactionalInterface;
  * @group headless
  */
 // phpcs:disable Generic.Files.LineLength.TooLong
-class api_v3_TwingleProduct_DeleteTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+class api_v3_TwingleProduct_DeleteTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
 // phpcs: enable
 
   use \Civi\Test\Api3TestTrait;

--- a/tests/phpunit/api/v3/TwingleProduct/DeleteTest.php
+++ b/tests/phpunit/api/v3/TwingleProduct/DeleteTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\HookInterface;
@@ -8,9 +10,13 @@ use Civi\Test\TransactionalInterface;
 /**
  * TwingleProduct.Delete API Test Case
  * This is a generic test class implemented with PHPUnit.
+ *
  * @group headless
  */
+// phpcs:disable Generic.Files.LineLength.TooLong
 class api_v3_TwingleProduct_DeleteTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+// phpcs: enable
+
   use \Civi\Test\Api3TestTrait;
 
   /**

--- a/tests/phpunit/api/v3/TwingleProduct/GetTest.php
+++ b/tests/phpunit/api/v3/TwingleProduct/GetTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\HookInterface;
@@ -8,9 +10,13 @@ use Civi\Test\TransactionalInterface;
 /**
  * TwingleProduct.Get API Test Case
  * This is a generic test class implemented with PHPUnit.
+ *
  * @group headless
  */
+// phpcs:disable Generic.Files.LineLength.TooLong
 class api_v3_TwingleProduct_GetTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+// phpcs: enable
+
   use \Civi\Test\Api3TestTrait;
 
   /**

--- a/tests/phpunit/api/v3/TwingleProduct/GetTest.php
+++ b/tests/phpunit/api/v3/TwingleProduct/GetTest.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**
@@ -14,7 +13,7 @@ use Civi\Test\TransactionalInterface;
  * @group headless
  */
 // phpcs:disable Generic.Files.LineLength.TooLong
-class api_v3_TwingleProduct_GetTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+class api_v3_TwingleProduct_GetTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
 // phpcs: enable
 
   use \Civi\Test\Api3TestTrait;

--- a/tests/phpunit/api/v3/TwingleProduct/GetsingleTest.php
+++ b/tests/phpunit/api/v3/TwingleProduct/GetsingleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\HookInterface;
@@ -8,9 +10,13 @@ use Civi\Test\TransactionalInterface;
 /**
  * TwingleProduct.Getsingle API Test Case
  * This is a generic test class implemented with PHPUnit.
+ *
  * @group headless
  */
+// phpcs:disable Generic.Files.LineLength.TooLong
 class api_v3_TwingleProduct_GetsingleTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+// phpcs: enable
+
   use \Civi\Test\Api3TestTrait;
 
   /**

--- a/tests/phpunit/api/v3/TwingleProduct/GetsingleTest.php
+++ b/tests/phpunit/api/v3/TwingleProduct/GetsingleTest.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**
@@ -14,7 +13,7 @@ use Civi\Test\TransactionalInterface;
  * @group headless
  */
 // phpcs:disable Generic.Files.LineLength.TooLong
-class api_v3_TwingleProduct_GetsingleTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+class api_v3_TwingleProduct_GetsingleTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
 // phpcs: enable
 
   use \Civi\Test\Api3TestTrait;

--- a/tests/phpunit/api/v3/TwingleShop/CreateTest.php
+++ b/tests/phpunit/api/v3/TwingleShop/CreateTest.php
@@ -1,16 +1,21 @@
 <?php
 
+declare(strict_types = 1);
+
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**
  * TwingleShop.Create API Test Case
  * This is a generic test class implemented with PHPUnit.
+ *
  * @group headless
  */
-class api_v3_TwingleShop_CreateTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+// phpcs:disable Generic.Files.LineLength.TooLong
+class api_v3_TwingleShop_CreateTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
+// phpcs: enable
+
   use \Civi\Test\Api3TestTrait;
 
   /**

--- a/tests/phpunit/api/v3/TwingleShop/DeleteTest.php
+++ b/tests/phpunit/api/v3/TwingleShop/DeleteTest.php
@@ -1,16 +1,21 @@
 <?php
 
+declare(strict_types = 1);
+
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**
  * TwingleShop.Delete API Test Case
  * This is a generic test class implemented with PHPUnit.
+ *
  * @group headless
  */
-class api_v3_TwingleShop_DeleteTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+// phpcs:disable Generic.Files.LineLength.TooLong
+class api_v3_TwingleShop_DeleteTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
+// phpcs: enable
+
   use \Civi\Test\Api3TestTrait;
 
   /**

--- a/tests/phpunit/api/v3/TwingleShop/GetTest.php
+++ b/tests/phpunit/api/v3/TwingleShop/GetTest.php
@@ -1,16 +1,21 @@
 <?php
 
+declare(strict_types = 1);
+
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**
  * TwingleShop.Get API Test Case
  * This is a generic test class implemented with PHPUnit.
+ *
  * @group headless
  */
-class api_v3_TwingleShop_GetTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+// phpcs:disable Generic.Files.LineLength.TooLong
+class api_v3_TwingleShop_GetTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
+// phpcs: enable
+
   use \Civi\Test\Api3TestTrait;
 
   /**

--- a/tests/phpunit/api/v3/TwingleShop/GetsingleTest.php
+++ b/tests/phpunit/api/v3/TwingleShop/GetsingleTest.php
@@ -1,16 +1,21 @@
 <?php
 
+declare(strict_types = 1);
+
 use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**
  * TwingleShop.Getsingle API Test Case
  * This is a generic test class implemented with PHPUnit.
+ *
  * @group headless
  */
-class api_v3_TwingleShop_GetsingleTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+// phpcs:disable Generic.Files.LineLength.TooLong
+class api_v3_TwingleShop_GetsingleTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
+// phpcs: enable
+
   use \Civi\Test\Api3TestTrait;
 
   /**


### PR DESCRIPTION
*twingle* recently started sending a booking date of transactions in a new parameter `booked_at` if available, alongside the current `confirmed_at` parameter. The latter might not be of use, e.g. when importing transactions from a bank account statement making the `confirmed_at` the date of the import, while the relevant booking date has not been sent to CiviCRM at all until now. Depending on the payment method, the booking date might also be available for donations made through *twingle* (e.g. for *PayPal* where funds are transmitted instantly), while e.g. for credit card or ETF payments the booking date is unknown when *twingle* send transactions to CiviCRM.

This adds a new profile option *Use booking date* (defaulting to `TRUE` for new profiles, but leaving existing profiles at `FALSE` for backwards-compatibility). With this option enabled, and a booking date being available, the contribution will be created with the booking date, falling back to the confirmation date if no booking date is available.

*systopia-reference: 27699*