### PR TITLE
Create database tables for the shop during installation

### DIFF
--- a/CRM/Twingle/Upgrader.php
+++ b/CRM/Twingle/Upgrader.php
@@ -29,6 +29,9 @@ class CRM_Twingle_Upgrader extends CRM_Extension_Upgrader_Base {
     // create a DB table for the twingle profiles
     $this->executeSqlFile('sql/civicrm_twingle_profile.sql');
 
+    // create DB tables for the twingle shop
+    $this->executeSqlFile('sql/civicrm_twingle_shop.sql');
+
     // add a default profile
     CRM_Twingle_Profile::createDefaultProfile()->saveProfile();
   }


### PR DESCRIPTION
For some reason, I had always assumed that the update functions would also be executed in sequence during installation. My bad!

Tested this on a fresh buildkit installation.

Fix #113
