### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,13 +14,13 @@
     <url desc="Support">https://github.com/systopia/de.systopia.twingle/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate></releaseDate>
+  <releaseDate/>
   <version>1.7.0-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.58</ver>
+    <ver>5.65</ver>
   </compatibility>
-  <comments></comments>
+  <comments/>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>
     <psr0 prefix="CRM_" path="."/>

--- a/templates/CRM/Twingle/Form/Profile.tpl
+++ b/templates/CRM/Twingle/Form/Profile.tpl
@@ -33,7 +33,7 @@
             <a
                     onclick='
                             CRM.help(
-                            "{ts domain="de.systopia.twingle"}Project IDs{/ts}",
+                            "{ts escape='htmlattribute' domain="de.systopia.twingle"}Project IDs{/ts}",
                     {literal}{
                       "id": "id-project_ids",
                       "file": "CRM\/Twingle\/Form\/Profile"
@@ -42,7 +42,7 @@
                             return false;
                             '
                     href="#"
-                    title="{ts domain="de.systopia.twingle"}Help{/ts}"
+                    title="{ts escape='htmlattribute' domain="de.systopia.twingle"}Help{/ts}"
                     class="helpicon"
             ></a>
           </td>
@@ -55,7 +55,7 @@
             <a
                     onclick='
                             CRM.help(
-                            "{ts domain="de.systopia.twingle"}XCM Profile{/ts}",
+                            "{ts escape='htmlattribute' domain="de.systopia.twingle"}XCM Profile{/ts}",
                     {literal}{
                       "id": "id-xcm_profile",
                       "file": "CRM\/Twingle\/Form\/Profile"
@@ -64,7 +64,7 @@
                             return false;
                             '
                     href="#"
-                    title="{ts domain="de.systopia.twingle"}Help{/ts}"
+                    title="{ts escape='htmlattribute' domain="de.systopia.twingle"}Help{/ts}"
                     class="helpicon"
             ></a>
           </td>
@@ -77,7 +77,7 @@
             <a
                     onclick='
                             CRM.help(
-                            "{ts domain="de.systopia.twingle"}Location type{/ts}",
+                            "{ts escape='htmlattribute' domain="de.systopia.twingle"}Location type{/ts}",
                     {literal}{
                       "id": "id-location_type_id",
                       "file": "CRM\/Twingle\/Form\/Profile"
@@ -86,7 +86,7 @@
                             return false;
                             '
                     href="#"
-                    title="{ts domain="de.systopia.twingle"}Help{/ts}"
+                    title="{ts escape='htmlattribute' domain="de.systopia.twingle"}Help{/ts}"
                     class="helpicon"
             ></a>
           </td>
@@ -99,7 +99,7 @@
             <a
               onclick='
                 CRM.help(
-                  "{ts domain="de.systopia.twingle"}Location type for organisations{/ts}",
+                  "{ts escape='htmlattribute' domain="de.systopia.twingle"}Location type for organisations{/ts}",
                   {literal}{
                     "id": "id-location_type_id_organisation",
                     "file": "CRM\/Twingle\/Form\/Profile"
@@ -108,7 +108,7 @@
                 return false;
               '
               href="#"
-              title="{ts domain="de.systopia.twingle"}Help{/ts}"
+              title="{ts escape='htmlattribute' domain="de.systopia.twingle"}Help{/ts}"
               class="helpicon"
             ></a>
           </td>
@@ -120,7 +120,7 @@
             <a
                     onclick='
                             CRM.help(
-                            "{ts domain="de.systopia.twingle"}Required address components{/ts}",
+                            "{ts escape='htmlattribute' domain="de.systopia.twingle"}Required address components{/ts}",
                     {literal}{
                       "id": "id-required_address_components",
                       "file": "CRM\/Twingle\/Form\/Profile"
@@ -129,7 +129,7 @@
                             return false;
                             '
                     href="#"
-                    title="{ts domain="de.systopia.twingle"}Help{/ts}"
+                    title="{ts escape='htmlattribute' domain="de.systopia.twingle"}Help{/ts}"
                     class="helpicon"
             ></a>
           </td>
@@ -142,7 +142,7 @@
             <a
                     onclick='
                             CRM.help(
-                            "{ts domain="de.systopia.twingle"}Financial type{/ts}",
+                            "{ts escape='htmlattribute' domain="de.systopia.twingle"}Financial type{/ts}",
                     {literal}{
                       "id": "id-financial_type_id",
                       "file": "CRM\/Twingle\/Form\/Profile"
@@ -151,7 +151,7 @@
                             return false;
                             '
                     href="#"
-                    title="{ts domain="de.systopia.twingle"}Help{/ts}"
+                    title="{ts escape='htmlattribute' domain="de.systopia.twingle"}Help{/ts}"
                     class="helpicon"
             ></a>
           </td>
@@ -164,7 +164,7 @@
             <a
                     onclick='
                             CRM.help(
-                            "{ts domain="de.systopia.twingle"}Financial type (recurring){/ts}",
+                            "{ts escape='htmlattribute' domain="de.systopia.twingle"}Financial type (recurring){/ts}",
                     {literal}{
                       "id": "id-financial_type_id_recur",
                       "file": "CRM\/Twingle\/Form\/Profile"
@@ -173,7 +173,7 @@
                             return false;
                             '
                     href="#"
-                    title="{ts domain="de.systopia.twingle"}Help{/ts}"
+                    title="{ts escape='htmlattribute' domain="de.systopia.twingle"}Help{/ts}"
                     class="helpicon"
             ></a>
           </td>
@@ -247,7 +247,7 @@
             <a
                     onclick='
                             CRM.help(
-                            "{ts domain="de.systopia.twingle"}Newsletter Double Opt-In{/ts}",
+                            "{ts escape='htmlattribute' domain="de.systopia.twingle"}Newsletter Double Opt-In{/ts}",
                     {literal}{
                       "id": "id-newsletter-double-opt-in",
                       "file": "CRM\/Twingle\/Form\/Profile"
@@ -256,7 +256,7 @@
                             return false;
                             '
                     href="#"
-                    title="{ts domain="de.systopia.twingle"}Help{/ts}"
+                    title="{ts escape='htmlattribute' domain="de.systopia.twingle"}Help{/ts}"
                     class="helpicon"
             ></a>
           </td>
@@ -297,7 +297,7 @@
             <a
                     onclick='
                             CRM.help(
-                            "{ts domain="de.systopia.twingle"}Membership Postprocessing{/ts}",
+                            "{ts escape='htmlattribute' domain="de.systopia.twingle"}Membership Postprocessing{/ts}",
                     {literal}{
                       "id": "id-membership-postprocessing-call",
                       "file": "CRM\/Twingle\/Form\/Profile"
@@ -306,7 +306,7 @@
                             return false;
                             '
                     href="#"
-                    title="{ts domain="de.systopia.twingle"}Help{/ts}"
+                    title="{ts escape='htmlattribute' domain="de.systopia.twingle"}Help{/ts}"
                     class="helpicon"
             ></a>
           </td>
@@ -340,7 +340,7 @@
             <a
                     onclick='
                             CRM.help(
-                            "{ts domain="de.systopia.twingle"}Custom field mapping{/ts}",
+                            "{ts escape='htmlattribute' domain="de.systopia.twingle"}Custom field mapping{/ts}",
                     {literal}{
                       "id": "id-custom_field_mapping",
                       "file": "CRM\/Twingle\/Form\/Profile"
@@ -349,7 +349,7 @@
                             return false;
                             '
                     href="#"
-                    title="{ts domain="de.systopia.twingle"}Help{/ts}"
+                    title="{ts escape='htmlattribute' domain="de.systopia.twingle"}Help{/ts}"
                     class="helpicon"
             ></a>
           </td>
@@ -369,7 +369,7 @@
             <a
               onclick='
                 CRM.help(
-                "{ts domain="de.systopia.twingle"}Enable Shop Integration{/ts}",
+                "{ts escape='htmlattribute' domain="de.systopia.twingle"}Enable Shop Integration{/ts}",
               {literal}{
                 "id": "id-enable_shop_integration",
                 "file": "CRM\/Twingle\/Form\/Profile"
@@ -378,7 +378,7 @@
                 return false;
                 '
               href="#"
-              title="{ts domain="de.systopia.twingle"}Help{/ts}"
+              title="{ts escape='htmlattribute' domain="de.systopia.twingle"}Help{/ts}"
               class="helpicon"
             ></a>
           </td>
@@ -400,7 +400,7 @@
               <a
                 onclick='
                   CRM.help(
-                  "{ts domain="de.systopia.twingle"}Map Products as Price Fields{/ts}",
+                  "{ts escape='htmlattribute' domain="de.systopia.twingle"}Map Products as Price Fields{/ts}",
                 {literal}{
                   "id": "id-shop_map_products",
                   "file": "CRM\/Twingle\/Form\/Profile"
@@ -409,7 +409,7 @@
                   return false;
                   '
                 href="#"
-                title="{ts domain="de.systopia.twingle"}Help{/ts}"
+                title="{ts escape='htmlattribute' domain="de.systopia.twingle"}Help{/ts}"
                 class="helpicon"
               ></a></td>
             <td class="content">{$form.shop_map_products.html}

--- a/templates/CRM/Twingle/Page/Configuration.tpl
+++ b/templates/CRM/Twingle/Page/Configuration.tpl
@@ -14,10 +14,10 @@
 <div class="crm-block crm-content-block">
   <div class="crm-submit-buttons">
 
-    <a href="{crmURL p="civicrm/admin/settings/twingle/profiles"}" title="{ts domain="de.systopia.twingle"}Profiles{/ts}" class="button">
+    <a href="{crmURL p="civicrm/admin/settings/twingle/profiles"}" title="{ts escape='htmlattribute' domain="de.systopia.twingle"}Profiles{/ts}" class="button">
       <span>{ts domain="de.systopia.twingle"}Configure profiles{/ts}</span>
     </a>
-    <a href="{crmURL p="civicrm/admin/settings/twingle/settings"}" title="{ts domain="de.systopia.twingle"}Settings{/ts}" class="button">
+    <a href="{crmURL p="civicrm/admin/settings/twingle/settings"}" title="{ts escape='htmlattribute' domain="de.systopia.twingle"}Settings{/ts}" class="button">
       <span>{ts domain="de.systopia.twingle"}Configure extension settings{/ts}</span>
     </a>
 

--- a/templates/CRM/Twingle/Page/Profiles.tpl
+++ b/templates/CRM/Twingle/Page/Profiles.tpl
@@ -15,7 +15,7 @@
 <div class="crm-block crm-content-block crm-twingle-content-block">
 
   <div class="crm-submit-buttons">
-    <a href="{crmURL p="civicrm/admin/settings/twingle/profile" q="op=create"}" title="{ts domain="de.systopia.twingle"}New profile{/ts}" class="button">
+    <a href="{crmURL p="civicrm/admin/settings/twingle/profile" q="op=create"}" title="{ts escape='htmlattribute' domain="de.systopia.twingle"}New profile{/ts}" class="button">
       <span><i class="crm-i fa-plus-circle"></i> {ts domain="de.systopia.twingle"}New profile{/ts}</span>
     </a>
   </div>
@@ -55,12 +55,12 @@
           <td>{ts domain="de.systopia.twingle"}{$profile_stats.$profile_name.access_counter_txt}{/ts}</td>
           <td>{ts domain="de.systopia.twingle"}{$profile_stats.$profile_name.last_access_txt}{/ts}</td>
           <td>
-            <a href="{crmURL p="civicrm/admin/settings/twingle/profile" q="op=edit&id=$profile_id"}" title="{ts domain="de.systopia.twingle" 1=$profile.name}Edit profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.twingle"}Edit{/ts}</a>
-            <a href="{crmURL p="civicrm/admin/settings/twingle/profile" q="op=copy&source_id=$profile_id"}" title="{ts domain="de.systopia.twingle" 1=$profile.name}Copy profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.twingle"}Copy{/ts}</a>
+            <a href="{crmURL p="civicrm/admin/settings/twingle/profile" q="op=edit&id=$profile_id"}" title="{ts escape='htmlattribute' domain="de.systopia.twingle" 1=$profile.name}Edit profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.twingle"}Edit{/ts}</a>
+            <a href="{crmURL p="civicrm/admin/settings/twingle/profile" q="op=copy&source_id=$profile_id"}" title="{ts escape='htmlattribute' domain="de.systopia.twingle" 1=$profile.name}Copy profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.twingle"}Copy{/ts}</a>
             {if $profile_name == 'default'}
-              <a href="{crmURL p="civicrm/admin/settings/twingle/profile" q="op=delete&id=$profile_id"}" title="{ts domain="de.systopia.twingle" 1=$profile.name}Reset profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.twingle"}Reset{/ts}</a>
+              <a href="{crmURL p="civicrm/admin/settings/twingle/profile" q="op=delete&id=$profile_id"}" title="{ts escape='htmlattribute' domain="de.systopia.twingle" 1=$profile.name}Reset profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.twingle"}Reset{/ts}</a>
             {else}
-              <a href="{crmURL p="civicrm/admin/settings/twingle/profile" q="op=delete&id=$profile_id"}" title="{ts domain="de.systopia.twingle" 1=$profile.name}Delete profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.twingle"}Delete{/ts}</a>
+              <a href="{crmURL p="civicrm/admin/settings/twingle/profile" q="op=delete&id=$profile_id"}" title="{ts escape='htmlattribute' domain="de.systopia.twingle" 1=$profile.name}Delete profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.twingle"}Delete{/ts}</a>
             {/if}
           </td>
         </tr>


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.