### PR TITLE
TwingleShop: add setting for the financial type of additional donations

### DIFF
--- a/CRM/Twingle/Form/Profile.php
+++ b/CRM/Twingle/Form/Profile.php
@@ -564,6 +564,15 @@ class CRM_Twingle_Form_Profile extends CRM_Core_Form {
       );
 
       $this->add(
+        'select',
+        'shop_additional_donation_financial_type',
+        E::ts('Financial Type for additional donations'),
+        static::getFinancialTypes(),
+        TRUE,
+        ['class' => 'crm-select2 huge']
+      );
+
+      $this->add(
         'checkbox',
         'shop_map_products',
         E::ts('Map Products as Price Fields')

--- a/CRM/Twingle/Profile.php
+++ b/CRM/Twingle/Profile.php
@@ -562,6 +562,7 @@ class CRM_Twingle_Profile {
         'enable_shop_integration' => ['required' => FALSE],
         'shop_financial_type' => ['required' => FALSE],
         'shop_donation_financial_type' => ['required' => FALSE],
+        'shop_additional_donation_financial_type' => ['required' => FALSE],
         'shop_map_products' => ['required' => FALSE],
       ],
       // Add payment methods.
@@ -685,6 +686,7 @@ class CRM_Twingle_Profile {
       'enable_shop_integration' => FALSE,
       'shop_financial_type' => 1,
       'shop_donation_financial_type' => 1,
+      'shop_additional_donation_financial_type' => 1,
       'shop_map_products' => FALSE,
     ]
     // Add contribution status for all payment methods.

--- a/CRM/Twingle/Submission.php
+++ b/CRM/Twingle/Submission.php
@@ -98,6 +98,19 @@ class CRM_Twingle_Submission {
   }
 
   /**
+   *  Twingle's internal ID for additional donations.
+   *  It's always -22, as stated here: https://github.com/systopia/de.systopia.twingle/issues/102#issuecomment-3337387888
+   */
+  private const TWINGLE_ADDITIONAL_DONATION_ID = -22;
+
+  /**
+   * @param array &$params
+   *   A reference to the parameters array of the submission.
+   *
+   * @param \CRM_Twingle_Profile $profile
+   *   The Twingle profile to use for validation, defaults to the default
+   *   profile.
+   *
    * @throws \CRM_Core_Exception
    *   When invalid parameters have been submitted.
    */
@@ -1238,6 +1251,11 @@ class CRM_Twingle_Submission {
         $line_item_data['price_field_value_id'] = $price_field->getPriceFieldValueId();
         $line_item_data['price_field_id'] = $price_field->price_field_id;
         $line_item_data['description'] = $price_field->description;
+      }
+      // Identify additional donations by their ID.
+      elseif ($product['id'] === self::TWINGLE_ADDITIONAL_DONATION_ID) {
+        $additional_donation_financial_type_id = $profile->getAttribute('shop_additional_donation_financial_type', 1);
+        $line_item_data['financial_type_id'] = $additional_donation_financial_type_id;
       }
       // If not found, use the shops default financial type
       else {

--- a/CRM/Twingle/Submission.php
+++ b/CRM/Twingle/Submission.php
@@ -98,8 +98,8 @@ class CRM_Twingle_Submission {
   }
 
   /**
-   *  Twingle's internal ID for additional donations.
-   *  It's always -22, as stated here: https://github.com/systopia/de.systopia.twingle/issues/102#issuecomment-3337387888
+   * Twingle's internal ID for additional donations.
+   * It's always -22, as stated here: https://github.com/systopia/de.systopia.twingle/issues/102#issuecomment-3337387888
    */
   private const TWINGLE_ADDITIONAL_DONATION_ID = -22;
 

--- a/CRM/Twingle/Submission.php
+++ b/CRM/Twingle/Submission.php
@@ -1256,6 +1256,7 @@ class CRM_Twingle_Submission {
       elseif ($product['id'] === self::TWINGLE_ADDITIONAL_DONATION_ID) {
         $additional_donation_financial_type_id = $profile->getAttribute('shop_additional_donation_financial_type', 1);
         $line_item_data['financial_type_id'] = $additional_donation_financial_type_id;
+        $line_item_data['price_field_id'] = 1;  # Hard-code to 1 which is the default for "contribution_amount"
       }
       // If not found, use the shops default financial type
       else {
@@ -1296,6 +1297,7 @@ class CRM_Twingle_Submission {
         'unit_price' => $donation_sum,
         'line_total' => $donation_sum,
         'financial_type_id' => $donation_financial_type_id,
+        'price_field_id' => 1,  # Hard-code to 1 which is the default for "contribution_amount"
         'sequential' => 1,
       ];
 

--- a/CRM/Twingle/Submission.php
+++ b/CRM/Twingle/Submission.php
@@ -1297,7 +1297,8 @@ class CRM_Twingle_Submission {
         'unit_price' => $donation_sum,
         'line_total' => $donation_sum,
         'financial_type_id' => $donation_financial_type_id,
-        'price_field_id' => 1,  # Hard-code to 1 which is the default for "contribution_amount"
+        // Hard-code to 1 which is the default for "contribution_amount"
+        'price_field_id' => 1,
         'sequential' => 1,
       ];
 

--- a/l10n/de_DE/LC_MESSAGES/twingle.po
+++ b/l10n/de_DE/LC_MESSAGES/twingle.po
@@ -14,7 +14,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.0.1\n"
+"X-Generator: Poedit 3.7\n"
 
 #: CRM/Twingle/BAO/TwingleProduct.php
 msgid ""
@@ -504,9 +504,12 @@ msgstr "Standard-Zuwendungsart"
 
 #: CRM/Twingle/Form/Profile.php
 msgid "Financial Type for top up donations"
-msgstr "Zuwendungsart für zusätzliche Spenden"
+msgstr "Zuwendungsart für Zusatzbetrag (Top-up)"
 
-#: CRM/Twingle/Form/Profile.php templates/CRM/Twingle/Form/Profile.tpl
+#: CRM/Twingle/Form/Profile.php
+msgid "Financial Type for additional donations"
+msgstr "Zuwendungsart für Zusatzspende"
+
 msgid "Map Products as Price Fields"
 msgstr "Produkte Preisfeldern zuordnen"
 
@@ -1577,9 +1580,9 @@ msgid ""
 msgstr ""
 "Einige Organisationen haben bestimmte Vorschriften bzgl. der Erstellung von "
 "Mitgliedschaften. Da die Twingle-API nur ein \"reines\" "
-"Mitgliedschaftsobjekt erstellt, können Sie einen API-Aufruf (als 'Entität."
-"Aktion') angeben, um neu erstellt Mitgliedschaften an die Anforderungen "
-"Ihrer Organisation anzupassen."
+"Mitgliedschaftsobjekt erstellt, können Sie einen API-Aufruf (als "
+"'Entität.Aktion') angeben, um neu erstellt Mitgliedschaften an die "
+"Anforderungen Ihrer Organisation anzupassen."
 
 #: templates/CRM/Twingle/Form/Profile.hlp
 msgid ""
@@ -1668,8 +1671,8 @@ msgstr ""
 "    <p>Verwenden Sie immer die Notation <code>custom_[id]</code> für "
 "benutzerdefinierte Felder in CiviCRM.</p>\n"
 "    <p>Unterstützt werden Felder, die Twingle im Parameter "
-"<code>custom_fields</code> bereitstellt, sowie für alle anderen Parameter (z."
-"&nbsp;B. <code>user_extrafield</code>)</p>\n"
+"<code>custom_fields</code> bereitstellt, sowie für alle anderen Parameter "
+"(z.&nbsp;B. <code>user_extrafield</code>)</p>\n"
 "    <p>Es werden nur benutzerdefinierte CiviCRM-Felder der folgenden "
 "Entitäten unterstützt:</p>\n"
 "    <ul>\n"

--- a/l10n/twingle.pot
+++ b/l10n/twingle.pot
@@ -454,7 +454,10 @@ msgstr ""
 msgid "Financial Type for top up donations"
 msgstr ""
 
-#: CRM/Twingle/Form/Profile.php templates/CRM/Twingle/Form/Profile.tpl
+#: CRM/Twingle/Form/Profile.php
+msgid "Financial Type for additional donations"
+msgstr ""
+
 msgid "Map Products as Price Fields"
 msgstr ""
 

--- a/templates/CRM/Twingle/Form/Profile.tpl
+++ b/templates/CRM/Twingle/Form/Profile.tpl
@@ -396,6 +396,11 @@
           </tr>
 
           <tr class="crm-section twingle-shop-element">
+            <td class="label">{$form.shop_additional_donation_financial_type.label}</td>
+            <td class="content">{$form.shop_additional_donation_financial_type.html}</td>
+          </tr>
+
+          <tr class="crm-section twingle-shop-element">
             <td class="label">{$form.shop_map_products.label}
               <a
                 onclick='


### PR DESCRIPTION
I added a setting field for the financial type of additional donations.

As we learned in #102, the `id` of additional donations is always `-22`. The default financial type is `1`, which should be "donation" in most cases.

Could you please test the PR @GFF-DS?

fix #102 