### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Twingle/Submission.php
+++ b/CRM/Twingle/Submission.php
@@ -145,7 +145,7 @@ class CRM_Twingle_Submission {
           }, $products);
       }
       if (!is_array($params['products'])) {
-        throw new CiviCRM_API3_Exception(
+        throw new CRM_Core_Exception(
           E::ts('Invalid format for products.'),
           'invalid_format'
         );
@@ -472,7 +472,7 @@ class CRM_Twingle_Submission {
    * @param $profile
    *   The twingle profile used
    *
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    * @throws \CRM_Core_Exception
    * @throws \Civi\Twingle\Shop\Exceptions\LineItemException
    */
@@ -546,7 +546,7 @@ class CRM_Twingle_Submission {
 
       if (!empty($line_item['is_error'])) {
         $line_item_name = $line_item_data['name'];
-        throw new CiviCRM_API3_Exception(
+        throw new CRM_Core_Exception(
           E::ts("Could not create line item for product '%1'", [1 => $line_item_name]),
           'api_error'
         );
@@ -580,7 +580,7 @@ class CRM_Twingle_Submission {
       $donation_line_item = civicrm_api3('LineItem', 'create', $donation_line_item_data);
 
       if (!empty($donation_line_item['is_error'])) {
-        throw new CiviCRM_API3_Exception(
+        throw new CRM_Core_Exception(
           E::ts("Could not create line item for donation"),
           'api_error'
         );

--- a/api/v3/TwingleDonation/Submit.php
+++ b/api/v3/TwingleDonation/Submit.php
@@ -759,7 +759,7 @@ function civicrm_api3_twingle_donation_Submit($params) {
       } else {
         $mandate_id = $result_values['sepa_mandate']['id'];
         $message = E::LONG_NAME . ": could not find contribution for sepa mandate $mandate_id";
-        throw new CiviCRM_API3_Exception($message, 'api_error');
+        throw new CRM_Core_Exception($message, 'api_error');
       }
 
       // Add products as line items to the contribution

--- a/api/v3/TwingleProduct/Create.php
+++ b/api/v3/TwingleProduct/Create.php
@@ -109,7 +109,7 @@ function _civicrm_api3_twingle_product_Create_spec(&$spec) {
  *
  * @see civicrm_api3_create_success
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  * @throws \Exception
  */
 function civicrm_api3_twingle_product_Create($params): array {

--- a/api/v3/TwingleProduct/Delete.php
+++ b/api/v3/TwingleProduct/Delete.php
@@ -35,7 +35,7 @@ function _civicrm_api3_twingle_product_Delete_spec(&$spec) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception*@throws \Exception
+ * @throws CRM_Core_Exception*@throws \Exception
  * @throws \Exception
  * @see civicrm_api3_create_success
  *

--- a/api/v3/TwingleProduct/Get.php
+++ b/api/v3/TwingleProduct/Get.php
@@ -63,7 +63,7 @@ function _civicrm_api3_twingle_product_Get_spec(&$spec) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  * @see civicrm_api3_create_success
  *
  */

--- a/api/v3/TwingleProduct/Getsingle.php
+++ b/api/v3/TwingleProduct/Getsingle.php
@@ -23,7 +23,7 @@ function _civicrm_api3_twingle_product_Getsingle_spec(&$spec) {
  *
  * @see civicrm_api3_create_success
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_twingle_product_Getsingle($params) {
   // Filter for allowed params

--- a/api/v3/TwingleShop/Create.php
+++ b/api/v3/TwingleShop/Create.php
@@ -51,7 +51,7 @@ function _civicrm_api3_twingle_shop_Create_spec(&$spec) {
  *
  * @see civicrm_api3_create_success
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_twingle_shop_Create($params) {
   // Filter for allowed params

--- a/api/v3/TwingleShop/Delete.php
+++ b/api/v3/TwingleShop/Delete.php
@@ -35,7 +35,7 @@ function _civicrm_api3_twingle_shop_Delete_spec(&$spec) {
  * @return array
  *   API result descriptor
  *
- * @throws \API_Exception
+ * @throws \CRM_Core_Exception
  * @throws \Civi\Twingle\Shop\Exceptions\ShopException
  * @throws \Exception
  * @see civicrm_api3_create_success

--- a/api/v3/TwingleShop/Fetch.php
+++ b/api/v3/TwingleShop/Fetch.php
@@ -33,7 +33,7 @@ function _civicrm_api3_twingle_shop_Fetch_spec(&$spec) {
  *
  * @see civicrm_api3_create_success
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_twingle_shop_Fetch($params) {
   // Filter for allowed params

--- a/api/v3/TwingleShop/Get.php
+++ b/api/v3/TwingleShop/Get.php
@@ -58,7 +58,7 @@ function _civicrm_api3_twingle_shop_Get_spec(&$spec) {
  *
  * @see civicrm_api3_create_success
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_twingle_shop_Get($params) {
   // Filter for allowed params

--- a/api/v3/TwingleShop/Getsingle.php
+++ b/api/v3/TwingleShop/Getsingle.php
@@ -23,7 +23,7 @@ function _civicrm_api3_twingle_shop_Getsingle_spec(&$spec) {
  *
  * @see civicrm_api3_create_success
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_twingle_shop_Getsingle($params) {
   // Filter for allowed params


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.