### PR TITLE
Remove deprecated curl_close

### DIFF
--- a/Civi/Twingle/Shop/ApiCall.php
+++ b/Civi/Twingle/Shop/ApiCall.php
@@ -134,7 +134,6 @@ class ApiCall {
     $response = json_decode(curl_exec($curl), TRUE);
 
     if (empty($response)) {
-      curl_close($curl);
       throw new ApiCallError(
         E::ts('Call to Twingle API failed. Please check your api token.'),
         ApiCallError::ERROR_CODE_CONNECTION_FAILED,
@@ -163,7 +162,6 @@ class ApiCall {
   protected static function check_response_and_close($response, $curl) {
 
     $curl_status_code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-    curl_close($curl);
 
     if ($response === FALSE) {
       throw new ApiCallError(

--- a/Civi/Twingle/Shop/CurlWrapper.php
+++ b/Civi/Twingle/Shop/CurlWrapper.php
@@ -25,8 +25,6 @@ class CurlWrapper {
     return curl_getinfo($ch, $option);
   }
 
-  public function close($ch) {
-    curl_close($ch);
-  }
+  public function close($ch) {}
 
 }


### PR DESCRIPTION
The function `curl_close()` is deprecated; as of php 8.0 it does nothing.
See https://www.php.net/manual/en/function.curl-close.php